### PR TITLE
Fix Linux instruction in download.php

### DIFF
--- a/public_html/download.php
+++ b/public_html/download.php
@@ -71,7 +71,7 @@ if (file_exists('lib/compat/utils.php')) {
 				</div>
 				<div class="darkmode-txt" id='guide-tx1-heading'>
 					<p>
-						 For Linux users, RPCS3 is packaged using the AppImage format. To run, execute <span class="txt-highlight darkmode-highlight">chmod a+x ./rpcs3-*_linux64.AppImage</span>
+						 For Linux users, RPCS3 is packaged using the AppImage format. To run, execute <span class="txt-highlight darkmode-highlight">chmod a+x ./rpcs3-*_linux64.AppImage && ./rpcs3-*_linux64.AppImage</span>
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
The existing instruction for "running" the RPCS3 AppImage on Linux simply explains how to make the file executable, not how to actually run it. This PR fixes that issue by adding the command to actually run the AppImage to that text box.