### PR TITLE
Prevent .sha-spec labels from being accidently selected

### DIFF
--- a/public_html/lib/css/main.css
+++ b/public_html/lib/css/main.css
@@ -564,6 +564,11 @@
     margin-right: 5px;
     padding: 4px 8px;
     border: solid 1px #455971;
+    user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
 }
 #download-con-container {
     position: relative;


### PR DESCRIPTION
Prevent .sha-spec labels from being selected when double-clicking the values. As of right now, double-clicking the SHA hash selects the "-256" part of "SHA-256" alongside with the actual hash value, which is rather annoying for the purposes of copying and comparison. Same happens with file sizes and PR version number.