### PR TITLE
Update quickstart.php to include LG BP50NB40

### DIFF
--- a/public_html/quickstart.php
+++ b/public_html/quickstart.php
@@ -334,6 +334,9 @@
 					<p>
 						 LG <span class="txt-highlight darkmode-highlight">WH16NS48</span>
 					</p>
+					<p>
+						 LG <span class="txt-highlight darkmode-highlight">BP50NB40</span>
+					</p>
 				</div>
 			</div>
 			<div class="guide-con-container darkmode-panel">


### PR DESCRIPTION
Adds LG BP50NB40 as a compatible drive to the list.  Successfully dumped games with it.