### PR TITLE
Add the PUP file to Minimum System Requirements

### DIFF
--- a/public_html/lib/module/in-specs.php
+++ b/public_html/lib/module/in-specs.php
@@ -113,8 +113,19 @@
 		</div>
 	</div>
 	</a>
-	<div class="panel-con-container div-css-panel-right darkmode-panel div-css-noevent">
+	<a href='https://www.playstation.com/en-us/support/system-updates/ps3' target="_blank">
+	<div class="panel-con-container div-css-panel-right darkmode-panel">
+		<div class='div-css-panellink darkmode-invert'>
+		</div>
+		<div class='panel-ico-container darkmode-invert' style="background: url('/img/icons/list/ps3.png') no-repeat center;">
+		</div>
+		<div class="panel-tx1-heading darkmode-txt">
+			<p>
+				<b>+</b> PlayStation 3 .PUP system update file
+			</p>
+		</div>
 	</div>
+	</a>
 </div>
 <div class="container-tx1-heading div-css-heading darkmode-txt">
 	<h2>Windows Requirements</h2>


### PR DESCRIPTION
To follow-up on the various confusion-removing quickstart updates, I propose to add the PS3UPDAT.PUP to minimum system requirements as well. Currently, it's only listed under "recommended", making it seem like it's not required by the emulator, whereas in reality it is.