### PR TITLE
Add green highlighter to the firmware filename

### DIFF
--- a/public_html/lib/module/in-specs.php
+++ b/public_html/lib/module/in-specs.php
@@ -108,7 +108,7 @@
 		</div>
 		<div class="panel-tx1-heading darkmode-txt">
 			<p>
-				<b>+</b> PlayStation 3 PS3UPDAT.PUP system update file
+				<b>+</b> PlayStation 3 <span class="txt-highlight darkmode-highlight">PS3UPDAT.PUP</span> system update file
 			</p>
 		</div>
 	</div>


### PR DESCRIPTION
Make it stand out a bit more as an actual filename, same as all filenames are in the rest of the guide. Sorry for sending two requests so quickly, only thought of this after sending the last PR.