### PR TITLE
Added  extra LG BD-RE drives

### DIFF
--- a/public_html/quickstart.php
+++ b/public_html/quickstart.php
@@ -339,10 +339,16 @@
 						 LG <span class="highlight darkmode-highlight">WH14NS40</span>
 					</p>
 					<p>
+						 LG <span class="highlight darkmode-highlight">WH16NS40</span>
+					</p>
+					<p>
 						 LG <span class="highlight darkmode-highlight">WH16NS48</span>
 					</p>
 					<p>
 						 LG <span class="highlight darkmode-highlight">BP50NB40</span>
+					</p>
+					<p>
+						 LG <span class="highlight darkmode-highlight">BE16NU50</span>
 					</p>
 				</div>
 			</div>

--- a/public_html/quickstart.php
+++ b/public_html/quickstart.php
@@ -339,9 +339,6 @@
 						 LG <span class="highlight darkmode-highlight">WH14NS40</span>
 					</p>
 					<p>
-						 LG <span class="highlight darkmode-highlight">WH16NS40</span>
-					</p>
-					<p>
 						 LG <span class="highlight darkmode-highlight">WH16NS48</span>
 					</p>
 					<p>


### PR DESCRIPTION
Added 2 LG drives that can read PS3 discs. One is an external, the other is an internal that can still be used with a SATA-to-USB adapter.