### PR TITLE
Changes to highlighted text + Typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For local deployment, our only requirement is [Docker](http://docker.com/getdock
 docker-compose up
 ```
 
-From there, open a web browser of your choosing and navigate to your prefered [localhost](http://localhost:8080) address.
+From there, open a web browser of your choosing and navigate to your preferred [localhost](http://localhost:8080) address.
 However, you will need to access it from your browser by adding the `:8080` to your localhost address.
 
 This website uses a CronJob to fetch the Roadmap. Your CronJob should be similar to `php public_html/lib/cronjobs/cron.roadmap.php` (using the appropriate paths to the php executable and the public_html directory) with a recommended timing of once an hour (`0 * * * *`).

--- a/public_html/lib/css/main.css
+++ b/public_html/lib/css/main.css
@@ -1578,8 +1578,6 @@ a:hover {
 	height:16px
 }
 .highlight {
-	margin-right:8px;
-	margin-left:8px;
 	padding:4px 6px;
 	color:#0074e7;
 	border:solid 1px #0074e7;

--- a/public_html/lib/css/main.css
+++ b/public_html/lib/css/main.css
@@ -1580,6 +1580,7 @@ a:hover {
 .highlight {
 	padding:4px 6px;
 	color:#0074e7;
+	white-space:nowrap;
 	border:solid 1px #0074e7;
 	border-radius:4px;
 	background:rgba(0,128,255,.1)

--- a/public_html/quickstart.php
+++ b/public_html/quickstart.php
@@ -476,7 +476,7 @@
 			</div>
 
 			<div class="container-con-block darkmode-block">
-				<div class="anchorpoint" id="dumping_procddure_manual">
+				<div class="anchorpoint" id="dumping_procedure_manual">
 				</div>
 				<div class='container-con-wrapper'>
 					<div class="container-tx1-block darkmode-txt">


### PR DESCRIPTION
With regards to the highlighted text, I've added `white-space:nowrap;` to prevent word wrap cutting important details into two lines. I've also removed the margins to the left and right as they end up creating too much space in a line and break the flow when used in progress reports. Will be easier to just add spaces where absolutely required.

**Before**
![Before](https://user-images.githubusercontent.com/31934788/62451825-9be08d80-b78c-11e9-8f38-1b762ab468c9.png)

**After**
![After](https://user-images.githubusercontent.com/31934788/62451836-a0a54180-b78c-11e9-89de-b2be146c35c1.png)
