### PR TITLE
Move the One-click PS3 dumper header below the Linux option

### DIFF
--- a/public_html/download.php
+++ b/public_html/download.php
@@ -189,12 +189,12 @@ $build = Build::getLast();
 						<p class="download-desc">
 							 RPCS3 is still in its early stages of development and the binaries we produce are highly experimental. Do not expect stable performance or consistent compatibility as changes are always being made to the codebase. If you come across any regressions upon a new release, please be sure to report your findings on our forum. <br>
 							<br>
-							 For Linux users, RPCS3 is packaged using the AppImage format. To run, execute<span class="highlight darkmode-highlight">chmod a+x ./rpcs3-*_linux64.AppImage &amp;&amp; ./rpcs3-*_linux64.AppImage</span>
+							 For Linux users, RPCS3 is packaged using the AppImage format. To run, execute <span class="highlight darkmode-highlight">chmod a+x ./rpcs3-*_linux64.AppImage &amp;&amp; ./rpcs3-*_linux64.AppImage</span>
 							<br>
 							<br>
-							<b>Download using wget</b><span class="highlight darkmode-highlight">wget --content-disposition https://rpcs3.net/latest-appimage</span>
+							<b>Download using wget</b> <span class="highlight darkmode-highlight">wget --content-disposition https://rpcs3.net/latest-appimage</span>
 							<br>
-							<b>Download using curl</b><span class="highlight darkmode-highlight">curl -JLO https://rpcs3.net/latest-appimage</span>
+							<b>Download using curl</b> <span class="highlight darkmode-highlight">curl -JLO https://rpcs3.net/latest-appimage</span>
 						</p>
 					</div>
 				</div>

--- a/public_html/lib/module/ui-main-menu.php
+++ b/public_html/lib/module/ui-main-menu.php
@@ -53,11 +53,6 @@
 				<span>FAQ</span>
 			</div>
 			</a>
-			<a href='https://wiki.rpcs3.net'>
-			<div class="menu-btn-select">
-				<span>Wiki</span>
-			</div>
-			</a>
 			<div class="menu-btn-select" style="pointer-events: none;">
 				<span>|</span>
 			</div>
@@ -66,9 +61,14 @@
 				<span>GitHub</span>
 			</div>
 			</a>
-			<a href='https://www.youtube.com/channel/UCz3-0QxNr4S4gK0xaWy7exQ/featured' target="_blank">
+			<a href='https://forums.rpcs3.net' target="_blank">
 			<div class="menu-btn-select">
-				<span>YouTube</span>
+				<span>Forum</span>
+			</div>
+			</a>
+			<a href='https://wiki.rpcs3.net'>
+			<div class="menu-btn-select">
+				<span>Wiki</span>
 			</div>
 			</a>
 			<a href='https://discord.me/RPCS3' target="_blank">
@@ -76,9 +76,9 @@
 				<span>Discord</span>
 			</div>
 			</a>
-			<a href='https://forums.rpcs3.net' target="_blank">
+			<a href='https://www.youtube.com/channel/UCz3-0QxNr4S4gK0xaWy7exQ/featured' target="_blank">
 			<div class="menu-btn-select">
-				<span>Forum</span>
+				<span>YouTube</span>
 			</div>
 			</a>
 			<div class="menu-con-support support-subtrigger">

--- a/public_html/quickstart.php
+++ b/public_html/quickstart.php
@@ -412,6 +412,23 @@
 			</div>
 			
 			<div class="container-con-block darkmode-block">
+				<div class="anchorpoint" id="dumping_linux"></div>
+				<div class='container-con-wrapper'>
+					<div class="container-tx1-block darkmode-txt">
+						<h2>A command-line option for Linux users</h2>
+					</div>
+					<div class="container-tx2-block darkmode-txt">
+						<p>
+							If you're comfortable with the Linux command-line and you have a compatible BluRay drive, you can try ripping PlayStation 3 discs using a Python program called <a href="https://notabug.org/necklace/libray" target="_blank" rel="noopener noreferrer">LibRay</a>.
+						</p>
+						<p>
+							Do note that this method requires an <span class="highlight darkmode-highlight">.ird</span> file that matches your title ID to be available on <a href="http://jonnysp.bplaced.net" target="_blank" rel="noopener noreferrer">jonnysp.bplaced.net</a>. (libray will automatically attempt to download the correct <span class="highlight darkmode-highlight">.ird</span> file, if it exists, so you do not need to do so manually.) If a matching <span class="highlight darkmode-highlight">.ird</span> file is not present, please try the PS3 Disc Dumper mentioned below.
+						</p>
+					</div>
+				</div>
+			</div>
+
+			<div class="container-con-block darkmode-block">
 				<div class="anchorpoint" id="dumping_procedure"></div>
 				<div class='container-con-wrapper'>
 					<div class="container-tx1-block darkmode-txt">
@@ -426,25 +443,6 @@
 					</div>
 				</div>
 			</div>
-
-			<div class="container-con-block darkmode-block">
-				<div class="anchorpoint" id="dumping_linux"></div>
-				<div class='container-con-wrapper'>
-					<div class="container-tx1-block darkmode-txt">
-						<h2>A command-line option for Linux users</h2>
-					</div>
-					<div class="container-tx2-block darkmode-txt">
-						<p>
-							If you're comfortable with the Linux command-line and you have a compatible BluRay drive, you can try ripping PlayStation 3 discs using a Python program called <a href="https://notabug.org/necklace/libray" target="_blank" rel="noopener noreferrer">LibRay</a>.
-						</p>
-
-						<p>
-							Do note that this method requires an <span class="highlight darkmode-highlight">.ird</span> file that matches your title ID to be available on <a href="http://jonnysp.bplaced.net" target="_blank" rel="noopener noreferrer">jonnysp.bplaced.net</a>. (libray will automatically attempt to download the correct <span class="highlight darkmode-highlight">.ird</span> file, if it exists, so you do not need to do so manually.) If a matching <span class="highlight darkmode-highlight">.ird</span> file is not present, please try the PS3 Disc Dumper mentioned below.
-						</p>
-					</div>
-				</div>
-			</div>
-
 			<div class="guide-con-content darkmode-panel">
 				<div class='guide-ico-content darkmode-invert' style="background: url('/img/icons/list/download.png') no-repeat center;">
 				</div>


### PR DESCRIPTION
Some users were getting confused with the heading placement and think the one-click PS3 dumper is Linux only.

**Before**
![Screenshot (136)](https://user-images.githubusercontent.com/31934788/62889953-07fc5c00-bd60-11e9-957c-dfd6c4d10972.png)

**After**
![Screenshot (137)](https://user-images.githubusercontent.com/31934788/62889956-07fc5c00-bd60-11e9-8383-6c5dc2cf672a.png)
