### PR TITLE
Allow use of Flexbox for images in the blog

### DIFF
--- a/public_html/lib/css/main.css
+++ b/public_html/lib/css/main.css
@@ -1658,3 +1658,45 @@ a:hover {
 	text-align:inherit;
 	color: #455971
 }
+
+.image-container {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.flex-row-wrap {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.flex-col-wrap {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+}
+
+.flexchild-img {
+  flex-grow: 1;
+  margin: 10px;
+}
+
+.img-col-2 {
+  flex-basis: 50%;
+}
+
+.img-col-3 {
+  flex-basis: 33.33%;
+}
+
+.img-row-2 {
+  flex-basis: 450px;
+}
+
+.img-row-3 {
+  flex-basis: 250px;
+}
+
+.img-row-4 {
+  flex-basis: 200px;
+}

--- a/public_html/lib/css/scale.css
+++ b/public_html/lib/css/scale.css
@@ -119,16 +119,21 @@
 	.content-tx1-download {
 		display:none;
 	}
-}
-@media screen and (max-width:800px) {
 	.content-expand {
 		width:100%;
 	}
-}
-@media screen and (max-width:800px) {
 	.content-remove {
 		display:none;
 	}
+  .img-row-3 {
+    flex-basis: 450px;
+  }
+  .img-row-4 {
+    flex-basis: 250px;
+  }
+  .img-col-2, .img-col-3 {
+    flex-basis: 100%;
+  }
 }
 @media screen and (max-width:1395px) {
 	.member-img-flag {


### PR DESCRIPTION
Most of our images in the blog are currently set using tables. This makes it almost impossible to see images on Mobiles. So, I've set up a new template using Flexbox that will automatically show images in the column format when viewed on Mobile. 

Some low-res images of the same (best I could do from my laptop):

**Look of a 2x2 on desktop:**
![Desktop](https://user-images.githubusercontent.com/31934788/64925502-13cfb800-d80f-11e9-9e60-225b2880d726.png)

**Automatically changing to a column on Mobile:**
![Mobile - new](https://user-images.githubusercontent.com/31934788/64925503-13cfb800-d80f-11e9-8d37-e304154d02ff.png)

**Mobile before with tiny images:**
![Mobile - old](https://user-images.githubusercontent.com/31934788/64925504-13cfb800-d80f-11e9-887e-f0de99a43c03.png)

