### PR TITLE
Remove DirectX dependency from Quickstart guide

### DIFF
--- a/public_html/lib/module/ui-main-specs.php
+++ b/public_html/lib/module/ui-main-specs.php
@@ -131,23 +131,8 @@
 		</div>
 	</div>
 	</a>
-	<a href='https://www.microsoft.com/en-us/download/details.aspx?id=35' target="_blank">
-	<div class="panel-con-container panel-right button-enabled darkmode-panel">
-		<div class='panel-link darkmode-invert'>
-		</div>
-		<div class='panel-ico-container darkmode-invert' style="background: url('/img/icons/list/directx.png') no-repeat center;">
-		</div>
-		<div class="panel-tx1-heading darkmode-txt">
-			<p>
-				<b>Microsoft</b> DirectX End-User Runtime
-			</p>
-		</div>
-	</div>
-	</a>
-</div>
-<div class='panel-con-wrapper'>
 	<a href='https://rpcs3.net/blog/wp-content/uploads/2019/common/openssl_win64.7z' target="_blank">
-	<div class="panel-con-container panel-center button-enabled darkmode-panel">
+	<div class="panel-con-container panel-right button-enabled darkmode-panel">
 		<div class='panel-link darkmode-invert'>
 		</div>
 		<div class='panel-ico-container darkmode-invert' style="background: url('/img/icons/list/ssl.png') no-repeat center;">


### PR DESCRIPTION
Removed DirectX dependency and moved the OpenSSL dependency to its spot.