### PR TITLE
Add LG CH12NS30 drive

### DIFF
--- a/public_html/quickstart.php
+++ b/public_html/quickstart.php
@@ -342,6 +342,9 @@
 						 LG <span class="highlight darkmode-highlight">BU40N</span>
 					</p>
 					<p>
+						 LG <span class="highlight darkmode-highlight">CH12NS30</span>
+					</p>
+					<p>
 						 LG <span class="highlight darkmode-highlight">UH12NS30</span>
 					</p>
 					<p>


### PR DESCRIPTION
Hi!

I've successfully created a backup of my God of War III (BCES-00510) blu ray with my LG CH12NS30 (fw. 1.00) and PS3 Disc Dumper on Windows 7. The backup is correctly seen and loaded on the latest RPCS3. I can confirm this drive is usable for backups.

Thank you!