### PR TITLE
Savedata is not an application directory

### DIFF
--- a/public_html/download.php
+++ b/public_html/download.php
@@ -422,7 +422,7 @@ if (@include_once("lib/compat/objects/Build.php"))
 						<p class="download-desc">
 							For macOS users, simply open the downloaded .DMG file and drag and drop the RPCS3 app into your applications folder when prompted.
 							<br>
-							Once installed, your RPCS3 application directory will be found in: <span class="highlight darkmode-highlight">~/Library/Application Support/rpcs3/dev_hdd0/home/00000001/savedata/</span>
+							Once installed, your RPCS3 application support directory will be found in: <span class="highlight darkmode-highlight">~/Library/Application Support/rpcs3/</span>
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
Savedata is not an application directory.
I have asked where the app is stored and was informed that we should mention where the configuration data is instead. It appears the Mac jargon is Application Support. So update Download.php to be more accurate in the information provided.
Suggestions are welcome.