### PR TITLE
Add BW-14D1XT to compatbile blu-ray drive list

### DIFF
--- a/public_html/lib/module/inc-bdds.php
+++ b/public_html/lib/module/inc-bdds.php
@@ -182,8 +182,10 @@
 			</div>
 			<span>BW-16D1HT</span>
 		</div>
-		<div class="drives-con-inner drives-txt-hidden">
-			<span>XX-XXXXXX</span>
+		<div class="drives-con-inner darkmode-txt">
+			<div class="drives-ico-bluray darkmode-invert">
+			</div>
+			<span>BW-14D1XT</span>
 		</div>
 		<div class="drives-con-inner drives-txt-hidden">
 			<span>XX-XXXXXX</span>


### PR DESCRIPTION
According to DeViL303 his Asus 14D1XT can also read PS3 Discs https://www.psx-place.com/threads/ps3-disc-dumper-for-pc.26232/