### PR TITLE
Remove outdated dumping bluray methods

### DIFF
--- a/public_html/lib/module/quickstart/inc-quickstart-dumping-tools.php
+++ b/public_html/lib/module/quickstart/inc-quickstart-dumping-tools.php
@@ -6,7 +6,7 @@
 		</div>
 		<div class='container-con-wrapper'>
 			<div class="container-tx1-block darkmode-txt">
-				<h2>Using Windows or Linux w/ Disc Dumper</h2>
+				<h2>Using Windows, Linux or macOS w/ Disc Dumper</h2>
 			</div>
 			<div class="container-tx2-block darkmode-txt">
 				<p>
@@ -25,81 +25,6 @@
 		</div>
 		<div class="generic-tx1-button">
 			<span>Disc Dumper <span class="generic-tx2-label">36 MB - 13xforever</span></span>
-		</div>
-	</div>
-	</a>
-</div>
-<div class="container-con-block darkmode-block">
-	<div class="anchor-point" id="dumping_on_windows_advanced">
-	</div>
-	<div class='container-con-wrapper'>
-		<div class="container-tx1-block darkmode-txt">
-			<h2>Using Windows w/ Advanced Tools</h2>
-		</div>
-		<div class="container-tx2-block darkmode-txt">
-			<p>
-				 In case the easy way didn't work for you, here's a compiled list of the step-by-step instructions we used for dumping disc-based PlayStation 3 titles. (Not recommended) <br>
-				<br>
-				<b>For detailed information on dumping PlayStation 3 games using this tool, check the official <a href='https://wiki.rpcs3.net/index.php?title=Help:Dumping_PlayStation_3_games' target="_blank">RPCS3 Wiki</a>.</b>
-			</p>
-		</div>
-	</div>
-</div>
-<div class="generic-con-button ">
-	<a href='/cdn/tools/patcher.zip' download>
-	<div class="generic-btn-button">
-		<div class="generic-ico-button" style="background: url('/img/icons/buttons/patcher-h.png') no-repeat center">
-		</div>
-		<div class="generic-tx1-button">
-			<span>.iso Patcher <span class="generic-tx2-label">78 KB - BlackDaemon</span></span>
-		</div>
-	</div>
-	</a>
-	<a href="https://www.imgburn.com" target="_blank" rel="noopener noreferrer">
-	<div class="generic-btn-button">
-		<div class="generic-ico-button" style="background: url('/img/icons/buttons/imgburn-h.png') no-repeat center">
-		</div>
-		<div class="generic-tx1-button">
-			<span>ImgBurn <span class="generic-tx2-label">3.8 MB - Lightning UK!</span></span>
-		</div>
-	</div>
-	</a>
-	<a href='/cdn/tools/3k3y.zip' download>
-	<div class="generic-btn-button">
-		<div class="generic-ico-button" style="background: url('/img/icons/buttons/3k3y-h.png') no-repeat center">
-		</div>
-		<div class="generic-tx1-button">
-			<span>.iso Tools <span class="generic-tx2-label">3.3 MB - 3K3Y</span></span>
-		</div>
-	</div>
-	</a>
-</div>
-<div class="container-con-block darkmode-block">
-	<div class="anchor-point" id="dumping_on_linux">
-	</div>
-	<div class='container-con-wrapper'>
-		<div class="container-tx1-block darkmode-txt">
-			<h2>Using Linux w/ Command Line</h2>
-		</div>
-		<div class="container-tx2-block darkmode-txt">
-			<p>
-				 If you're comfortable with the Linux command-line and you have a compatible Blu-ray drive, you can try ripping PlayStation 3 discs using a Python program called <a href="https://notabug.org/necklace/libray" target="_blank" rel="noopener noreferrer">LibRay</a>.
-			</p>
-			<p>
-				 Do note that this method requires an .ird file that matches your title ID to be available on <a href="https://ps3.aldostools.org/ird.html" target="_blank" rel="noopener noreferrer">ps3.aldostools.org/ird</a>. (LibRay will automatically attempt to download the correct .ird file, if it exists, so you do not need to do so manually.) If a matching .ird file is not present, please try the PS3 Disc Dumper mentioned below. <br>
-				<br>
-				<b>For detailed information on dumping PlayStation 3 games using this tool, check the official <a href='https://wiki.rpcs3.net/index.php?title=Help:Dumping_PlayStation_3_games' target="_blank">RPCS3 Wiki</a>.</b>
-			</p>
-		</div>
-	</div>
-</div>
-<div class="generic-con-button ">
-	<a href='https://notabug.org/necklace/libray' target="_blank">
-	<div class="generic-btn-button">
-		<div class="generic-ico-button" style="background: url('/img/icons/buttons/notabug-h.png') no-repeat center">
-		</div>
-		<div class="generic-tx1-button">
-			<span>LibRay <span class="generic-tx2-label">30KB - Necklace</span></span>
 		</div>
 	</div>
 	</a>


### PR DESCRIPTION
13x Disc dumper is available on Windows, Linux and macOS and it does the job for a user with just 1 button press instead of doing everything manually.