### PR TITLE
lib/css: Undo unwanted changes from 5158eefa544fea465e8da83ffd4ec32bed82048c

### DIFF
--- a/public_html/lib/css/anim.css
+++ b/public_html/lib/css/anim.css
@@ -1,3092 +1,1378 @@
 @charset "utf-8";
 .fade-in-onload {
 	display:none;
-	-webkit-animation-name:fadeIn;
-	        animation-name:fadeIn;
-	-webkit-animation-duration:.5s;
-	        animation-duration:.5s;
-	-webkit-animation-iteration-count:1;
-	        animation-iteration-count:1;
+	animation-name:fadeIn;
+	animation-duration:.5s;
+	animation-iteration-count: 1;
 }
 .fade-up-onload {
 	display:none;
-	-webkit-animation-name:fadeInUp;
-	        animation-name:fadeInUp;
-	-webkit-animation-duration:.5s;
-	        animation-duration:.5s;
-	-webkit-animation-iteration-count:1;
-	        animation-iteration-count:1;
+	animation-name:fadeInUp;
+	animation-duration:.5s;
+	animation-iteration-count:1;
 }
 .fade-down-onload {
 	display:none;
-	-webkit-animation-name:fadeInDown;
-	        animation-name:fadeInDown;
-	-webkit-animation-duration:.5s;
-	        animation-duration:.5s;
-	-webkit-animation-iteration-count:1;
-	        animation-iteration-count:1;
+	animation-name:fadeInDown;
+	animation-duration:.5s;
+	animation-iteration-count:1;
 }
 .fade-left-onload {
 	display:none;
-	-webkit-animation-name:fadeInLeft;
-	        animation-name:fadeInLeft;
-	-webkit-animation-duration:.5s;
-	        animation-duration:.5s;
-	-webkit-animation-iteration-count:1;
-	        animation-iteration-count:1;
+	animation-name:fadeInLeft;
+	animation-duration:.5s;
+	animation-iteration-count:1;
 }
 .fade-right-onload {
 	display:none;
-	-webkit-animation-name:fadeInRight;
-	        animation-name:fadeInRight;
-	-webkit-animation-duration:.5s;
-	        animation-duration:.5s;
-	-webkit-animation-iteration-count: 1;
-	        animation-iteration-count: 1;
+	animation-name:fadeInRight;
+	animation-duration:.5s;
+	animation-iteration-count:1;
 }
 /*----------------------------------------------------------------------------*/
 .fade-up-onstart {
 	display:none;
-	-webkit-animation-name:fadeInUp;
-	        animation-name:fadeInUp;
-	-webkit-animation-duration:.5s;
-	        animation-duration:.5s;
-	-webkit-animation-iteration-count: 1;
-	        animation-iteration-count: 1;
+	animation-name:fadeInUp;
+	animation-duration:.5s;
+	animation-iteration-count:1;
 }
 /*----------------------------------------------------------------------------*/
 .animated {
-	-webkit-animation-duration:1s;
-	        animation-duration:1s;
-	-webkit-animation-fill-mode:both;
-	        animation-fill-mode:both;
+	animation-duration:1s;
+	animation-fill-mode:both;
 }
 .animated.infinite {
-	-webkit-animation-iteration-count:infinite;
-	        animation-iteration-count:infinite;
+	animation-iteration-count:infinite;
 }
 .animated.hinge {
-	-webkit-animation-duration:2s;
-	        animation-duration:2s;
+	animation-duration:2s;
 }
 .animated.bounceIn,.animated.bounceOut {
-	-webkit-animation-duration:.75s;
-	        animation-duration:.75s;
+	animation-duration:.75s;
 }
 .animated.flipOutX,.animated.flipOutY {
-	-webkit-animation-duration: .75s;
-	        animation-duration: .75s;
+	animation-duration: .75s;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes blobby {
-	0% {
-			d:path("M140.881198,194.260295 C257.600568,129.32862 342.939626,119.84993 418.009939,203.154617 C493.080251,286.459305 545.728689,70.9046172 636.439626,63.9593047 C727.150564,57.0139922 768.99822,139.670242 858.802907,119.431961 C948.607595,99.1936797 1071.91228,-32.9977266 1243.91228,7.75227342 C1415.91228,48.5022734 1404.10369,208.584305 1508.27166,178.709305 C1612.43963,148.834305 1633.73291,79.913472 1711.63588,98.8569055 C1776.28676,114.577866 1819.96778,221.391836 1889.37253,185.808108 C2017.32661,120.206212 2004.01952,336.769569 2004.01952,336.769569 L271.635881,337 L-149.063338,337 C-149.063338,337 -245.850307,175.637635 -58.0633382,228.867188 C33.8652851,254.92501 64.1722713,236.933925 140.881198,194.260295 Z")
-	}
-	50% {
-			d:path("M-60.13579,199.189799 C-33.8674767,-71.7287911 170.194454,11.9640675 274.985105,83.0972992 C379.775756,154.230531 409.072181,161.653171 521.54913,124.460269 C634.026079,87.2673683 645.348165,219.42808 735.152853,199.189799 C824.95754,178.951518 948.262228,46.7601116 1120.26223,87.5101116 C1292.26223,128.260112 1309.89513,321.347957 1414.0631,291.472957 C1518.23106,261.597957 1580.53259,89.5639434 1732.07052,88.5665294 C1892.57296,87.5101116 1897.70372,225.708266 2049.59054,199.189799 C2201.47736,172.671332 2002.94707,336.794682 2002.94707,336.794682 L270.563429,337.025114 L-60.13579,337.025114 C-60.13579,337.025114 -469.886827,134.917309 -282.099858,188.146862 C-190.171235,214.204685 -65.9645849,259.30515 -60.13579,199.189799 Z")
-	}
-	to {
-			d: path("M-160.553381,263.533987 C-124.4955,243.377988 -18.6139605,181.080724 56.456352,264.385412 C131.526664,347.690099 165.148428,226.409513 223.668826,168.5 C282.189224,110.590487 372.68516,208.331261 462.489847,188.09298 C552.294535,167.854699 723.262827,-40.1656225 847.424394,40.7522734 C971.58596,121.670169 1156.59375,252.295176 1300.40314,228.958726 C1444.21253,205.622277 1478.90991,106.221579 1563.51957,124.699258 C1655.80276,144.85274 1595.69955,250.007434 1832.41793,206.740235 C2069.1363,163.473036 2002.94707,336.794682 2002.94707,336.794682 L270.563429,337.025114 L-60.13579,337.025114 C-60.13579,337.025114 -495.794798,256.512987 -308.007829,309.74254 C-216.079206,335.800362 -208.740043,290.469854 -160.553381,263.533987 Z")
-	}
-}
 @keyframes blobby {
 	0% {
-			d:path("M140.881198,194.260295 C257.600568,129.32862 342.939626,119.84993 418.009939,203.154617 C493.080251,286.459305 545.728689,70.9046172 636.439626,63.9593047 C727.150564,57.0139922 768.99822,139.670242 858.802907,119.431961 C948.607595,99.1936797 1071.91228,-32.9977266 1243.91228,7.75227342 C1415.91228,48.5022734 1404.10369,208.584305 1508.27166,178.709305 C1612.43963,148.834305 1633.73291,79.913472 1711.63588,98.8569055 C1776.28676,114.577866 1819.96778,221.391836 1889.37253,185.808108 C2017.32661,120.206212 2004.01952,336.769569 2004.01952,336.769569 L271.635881,337 L-149.063338,337 C-149.063338,337 -245.850307,175.637635 -58.0633382,228.867188 C33.8652851,254.92501 64.1722713,236.933925 140.881198,194.260295 Z")
+		d:path("M140.881198,194.260295 C257.600568,129.32862 342.939626,119.84993 418.009939,203.154617 C493.080251,286.459305 545.728689,70.9046172 636.439626,63.9593047 C727.150564,57.0139922 768.99822,139.670242 858.802907,119.431961 C948.607595,99.1936797 1071.91228,-32.9977266 1243.91228,7.75227342 C1415.91228,48.5022734 1404.10369,208.584305 1508.27166,178.709305 C1612.43963,148.834305 1633.73291,79.913472 1711.63588,98.8569055 C1776.28676,114.577866 1819.96778,221.391836 1889.37253,185.808108 C2017.32661,120.206212 2004.01952,336.769569 2004.01952,336.769569 L271.635881,337 L-149.063338,337 C-149.063338,337 -245.850307,175.637635 -58.0633382,228.867188 C33.8652851,254.92501 64.1722713,236.933925 140.881198,194.260295 Z")
 	}
 	50% {
-			d:path("M-60.13579,199.189799 C-33.8674767,-71.7287911 170.194454,11.9640675 274.985105,83.0972992 C379.775756,154.230531 409.072181,161.653171 521.54913,124.460269 C634.026079,87.2673683 645.348165,219.42808 735.152853,199.189799 C824.95754,178.951518 948.262228,46.7601116 1120.26223,87.5101116 C1292.26223,128.260112 1309.89513,321.347957 1414.0631,291.472957 C1518.23106,261.597957 1580.53259,89.5639434 1732.07052,88.5665294 C1892.57296,87.5101116 1897.70372,225.708266 2049.59054,199.189799 C2201.47736,172.671332 2002.94707,336.794682 2002.94707,336.794682 L270.563429,337.025114 L-60.13579,337.025114 C-60.13579,337.025114 -469.886827,134.917309 -282.099858,188.146862 C-190.171235,214.204685 -65.9645849,259.30515 -60.13579,199.189799 Z")
+		d:path("M-60.13579,199.189799 C-33.8674767,-71.7287911 170.194454,11.9640675 274.985105,83.0972992 C379.775756,154.230531 409.072181,161.653171 521.54913,124.460269 C634.026079,87.2673683 645.348165,219.42808 735.152853,199.189799 C824.95754,178.951518 948.262228,46.7601116 1120.26223,87.5101116 C1292.26223,128.260112 1309.89513,321.347957 1414.0631,291.472957 C1518.23106,261.597957 1580.53259,89.5639434 1732.07052,88.5665294 C1892.57296,87.5101116 1897.70372,225.708266 2049.59054,199.189799 C2201.47736,172.671332 2002.94707,336.794682 2002.94707,336.794682 L270.563429,337.025114 L-60.13579,337.025114 C-60.13579,337.025114 -469.886827,134.917309 -282.099858,188.146862 C-190.171235,214.204685 -65.9645849,259.30515 -60.13579,199.189799 Z")
 	}
 	to {
-			d: path("M-160.553381,263.533987 C-124.4955,243.377988 -18.6139605,181.080724 56.456352,264.385412 C131.526664,347.690099 165.148428,226.409513 223.668826,168.5 C282.189224,110.590487 372.68516,208.331261 462.489847,188.09298 C552.294535,167.854699 723.262827,-40.1656225 847.424394,40.7522734 C971.58596,121.670169 1156.59375,252.295176 1300.40314,228.958726 C1444.21253,205.622277 1478.90991,106.221579 1563.51957,124.699258 C1655.80276,144.85274 1595.69955,250.007434 1832.41793,206.740235 C2069.1363,163.473036 2002.94707,336.794682 2002.94707,336.794682 L270.563429,337.025114 L-60.13579,337.025114 C-60.13579,337.025114 -495.794798,256.512987 -308.007829,309.74254 C-216.079206,335.800362 -208.740043,290.469854 -160.553381,263.533987 Z")
+		d:path("M-160.553381,263.533987 C-124.4955,243.377988 -18.6139605,181.080724 56.456352,264.385412 C131.526664,347.690099 165.148428,226.409513 223.668826,168.5 C282.189224,110.590487 372.68516,208.331261 462.489847,188.09298 C552.294535,167.854699 723.262827,-40.1656225 847.424394,40.7522734 C971.58596,121.670169 1156.59375,252.295176 1300.40314,228.958726 C1444.21253,205.622277 1478.90991,106.221579 1563.51957,124.699258 C1655.80276,144.85274 1595.69955,250.007434 1832.41793,206.740235 C2069.1363,163.473036 2002.94707,336.794682 2002.94707,336.794682 L270.563429,337.025114 L-60.13579,337.025114 C-60.13579,337.025114 -495.794798,256.512987 -308.007829,309.74254 C-216.079206,335.800362 -208.740043,290.469854 -160.553381,263.533987 Z")
 	}
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes wavebar-svg-object {
-	0% {
-			margin-left:0;
-	}
-	100% {
-			margin-left:-1600px;
-	}
-}
 @keyframes wavebar-svg-object {
 	0% {
-			margin-left:0;
+		margin-left:0;
 	}
 	100% {
-			margin-left:-1600px;
-	}
-}
-@-webkit-keyframes gpu-swell {
-	0%,100% {
-			-webkit-transform:translate3d(0,-24px,0);
-			        transform:translate3d(0,-24px,0);
-	}
-	50% {
-			-webkit-transform: translate3d(0,4px,0);
-			        transform: translate3d(0,4px,0);
+		margin-left:-1600px;
 	}
 }
 @keyframes gpu-swell {
 	0%,100% {
-			-webkit-transform:translate3d(0,-24px,0);
-			        transform:translate3d(0,-24px,0);
+		transform:translate3d(0,-24px,0);
 	}
 	50% {
-			-webkit-transform: translate3d(0,4px,0);
-			        transform: translate3d(0,4px,0);
+		transform: translate3d(0,4px,0);
 	}
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes spinnerRotate {
-	from {
-			-webkit-transform:rotate(0deg);
-			        transform:rotate(0deg);
-	}
-	to {
-			-webkit-transform: rotate(360deg);
-			        transform: rotate(360deg);
-	}
-}
 @keyframes spinnerRotate {
 	from {
-			-webkit-transform:rotate(0deg);
-			        transform:rotate(0deg);
+		transform:rotate(0deg);
 	}
 	to {
-			-webkit-transform: rotate(360deg);
-			        transform: rotate(360deg);
+		transform:rotate(360deg);
+
 	}
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes wave {
-	0%,60%,100% {
-				-webkit-transform:translateY(0);
-				        transform:translateY(0);
-				background:rgba(255,255,255,.05);
-	}
-	20% {
-				-webkit-transform:translateY(20px);
-				        transform:translateY(20px);
-				background:rgba(255,255,255,.75);
-	}
-	40% {
-				-webkit-transform:translateY(-20px);
-				        transform:translateY(-20px);
-				background: rgba(255,255,255,.75);
-	}
-}
 @keyframes wave {
 	0%,60%,100% {
-				-webkit-transform:translateY(0);
-				        transform:translateY(0);
-				background:rgba(255,255,255,.05);
+			transform:translateY(0);
+			background:rgba(255,255,255,.05);
 	}
 	20% {
-				-webkit-transform:translateY(20px);
-				        transform:translateY(20px);
-				background:rgba(255,255,255,.75);
+			transform:translateY(20px);
+			background:rgba(255,255,255,.75);
 	}
 	40% {
-				-webkit-transform:translateY(-20px);
-				        transform:translateY(-20px);
-				background: rgba(255,255,255,.75);
+			transform:translateY(-20px);
+			background:rgba(255,255,255,.75);
 	}
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounce {
-	from,20%,53%,80%,100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-	}
-	40%,43% {
-				-webkit-transform:translate3d(0,-30px,0);
-				        transform:translate3d(0,-30px,0);
-				-webkit-animation-timing-function:cubic-bezier(.755,.050,.855,.060);
-				        animation-timing-function:cubic-bezier(.755,.050,.855,.060);
-	}
-	70% {
-				-webkit-transform:translate3d(0,-15px,0);
-				        transform:translate3d(0,-15px,0);
-				-webkit-animation-timing-function:cubic-bezier(.755,.050,.855,.060);
-				        animation-timing-function:cubic-bezier(.755,.050,.855,.060);
-	}
-	90% {
-				-webkit-transform:translate3d(0,-4px,0);
-				        transform:translate3d(0,-4px,0);
-	}
-}
 @keyframes bounce {
 	from,20%,53%,80%,100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
+			transform:translate3d(0,0,0);
+			animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
 	}
 	40%,43% {
-				-webkit-transform:translate3d(0,-30px,0);
-				        transform:translate3d(0,-30px,0);
-				-webkit-animation-timing-function:cubic-bezier(.755,.050,.855,.060);
-				        animation-timing-function:cubic-bezier(.755,.050,.855,.060);
+			transform:translate3d(0,-30px,0);
+			animation-timing-function:cubic-bezier(.755,.050,.855,.060);
 	}
 	70% {
-				-webkit-transform:translate3d(0,-15px,0);
-				        transform:translate3d(0,-15px,0);
-				-webkit-animation-timing-function:cubic-bezier(.755,.050,.855,.060);
-				        animation-timing-function:cubic-bezier(.755,.050,.855,.060);
+			transform:translate3d(0,-15px,0);
+			animation-timing-function:cubic-bezier(.755,.050,.855,.060);
 	}
 	90% {
-				-webkit-transform:translate3d(0,-4px,0);
-				        transform:translate3d(0,-4px,0);
+			transform:translate3d(0,-4px,0);
 	}
 }
 .bounce {
-	-webkit-transform-origin:center bottom;
-	    -ms-transform-origin:center bottom;
-	        transform-origin:center bottom;
-	-webkit-animation-name: bounce;
-	        animation-name: bounce;
+	transform-origin:center bottom;
+	animation-name: bounce;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes flash {
-	from,50%,100% {
-				opacity:1;
-	}
-	25%,75% {
-				opacity:0;
-	}
-}
 @keyframes flash {
 	from,50%,100% {
-				opacity:1;
+			opacity:1;
 	}
 	25%,75% {
-				opacity:0;
+			opacity:0;
 	}
 }
 .flash {
-	-webkit-animation-name: flash;
-	        animation-name: flash;
+	animation-name:flash;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes pulse {
-	from {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
-	}
-	50% {
-				-webkit-transform:scale3d(1.05,1.05,1.05);
-				        transform:scale3d(1.05,1.05,1.05);
-	}
-	100% {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
-	}
-}
 @keyframes pulse {
 	from {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
+			transform:scale3d(1,1,1);
 	}
 	50% {
-				-webkit-transform:scale3d(1.05,1.05,1.05);
-				        transform:scale3d(1.05,1.05,1.05);
+			transform:scale3d(1.05,1.05,1.05);
 	}
 	100% {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
+			transform: scale3d(1,1,1);
 	}
 }
 .pulse {
-	-webkit-animation-name: pulse;
-	        animation-name: pulse;
+	animation-name:pulse;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes rubberBand {
-	from {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
-	}
-	30% {
-				-webkit-transform:scale3d(1.25,.75,1);
-				        transform:scale3d(1.25,.75,1);
-	}
-	40% {
-				-webkit-transform:scale3d(.75,1.25,1);
-				        transform:scale3d(.75,1.25,1);
-	}
-	50% {
-				-webkit-transform:scale3d(1.15,.85,1);
-				        transform:scale3d(1.15,.85,1);
-	}
-	65% {
-				-webkit-transform:scale3d(.95,1.05,1);
-				        transform:scale3d(.95,1.05,1);
-	}
-	75% {
-				-webkit-transform:scale3d(1.05,.95,1);
-				        transform:scale3d(1.05,.95,1);
-	}
-	100% {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
-	}
-}
 @keyframes rubberBand {
 	from {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
+			transform:scale3d(1,1,1);
 	}
 	30% {
-				-webkit-transform:scale3d(1.25,.75,1);
-				        transform:scale3d(1.25,.75,1);
+			transform:scale3d(1.25,.75,1);
 	}
 	40% {
-				-webkit-transform:scale3d(.75,1.25,1);
-				        transform:scale3d(.75,1.25,1);
+			transform:scale3d(.75,1.25,1);
 	}
 	50% {
-				-webkit-transform:scale3d(1.15,.85,1);
-				        transform:scale3d(1.15,.85,1);
+			transform:scale3d(1.15,.85,1);
 	}
 	65% {
-				-webkit-transform:scale3d(.95,1.05,1);
-				        transform:scale3d(.95,1.05,1);
+			transform:scale3d(.95,1.05,1);
 	}
 	75% {
-				-webkit-transform:scale3d(1.05,.95,1);
-				        transform:scale3d(1.05,.95,1);
+			transform:scale3d(1.05,.95,1);
 	}
 	100% {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
+			transform:scale3d(1,1,1);
 	}
 }
 .rubberBand {
-	-webkit-animation-name: rubberBand;
-	        animation-name: rubberBand;
+	animation-name: rubberBand;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes shake {
-	from,100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-	}
-	10%,30%,50%,70%,90% {
-				-webkit-transform:translate3d(-10px,0,0);
-				        transform:translate3d(-10px,0,0);
-	}
-	20%,40%,60%,80% {
-				-webkit-transform:translate3d(10px,0,0);
-				        transform:translate3d(10px,0,0);
-	}
-}
 @keyframes shake {
 	from,100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
+			transform:translate3d(0,0,0);
 	}
 	10%,30%,50%,70%,90% {
-				-webkit-transform:translate3d(-10px,0,0);
-				        transform:translate3d(-10px,0,0);
+			transform:translate3d(-10px,0,0);
 	}
 	20%,40%,60%,80% {
-				-webkit-transform:translate3d(10px,0,0);
-				        transform:translate3d(10px,0,0);
+			transform:translate3d(10px,0,0);
 	}
 }
 .shake {
-	-webkit-animation-name: shake;
-	        animation-name: shake;
+	animation-name: shake;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes swing {
-	20% {
-				-webkit-transform:rotate3d(0,0,1,15deg);
-				        transform:rotate3d(0,0,1,15deg);
-	}
-	40% {
-				-webkit-transform:rotate3d(0,0,1,-10deg);
-				        transform:rotate3d(0,0,1,-10deg);
-	}
-	60% {
-				-webkit-transform:rotate3d(0,0,1,5deg);
-				        transform:rotate3d(0,0,1,5deg);
-	}
-	80% {
-				-webkit-transform:rotate3d(0,0,1,-5deg);
-				        transform:rotate3d(0,0,1,-5deg);
-	}
-	100% {
-				-webkit-transform:rotate3d(0,0,1,0deg);
-				        transform:rotate3d(0,0,1,0deg);
-	}
-}
 @keyframes swing {
 	20% {
-				-webkit-transform:rotate3d(0,0,1,15deg);
-				        transform:rotate3d(0,0,1,15deg);
+			transform:rotate3d(0,0,1,15deg);
 	}
 	40% {
-				-webkit-transform:rotate3d(0,0,1,-10deg);
-				        transform:rotate3d(0,0,1,-10deg);
+			transform:rotate3d(0,0,1,-10deg);
 	}
 	60% {
-				-webkit-transform:rotate3d(0,0,1,5deg);
-				        transform:rotate3d(0,0,1,5deg);
+			transform:rotate3d(0,0,1,5deg);
 	}
 	80% {
-				-webkit-transform:rotate3d(0,0,1,-5deg);
-				        transform:rotate3d(0,0,1,-5deg);
+			transform:rotate3d(0,0,1,-5deg);
 	}
 	100% {
-				-webkit-transform:rotate3d(0,0,1,0deg);
-				        transform:rotate3d(0,0,1,0deg);
+			transform:rotate3d(0,0,1,0deg);
 	}
 }
 .swing {
-	-webkit-transform-origin:top center;
-	    -ms-transform-origin:top center;
-	        transform-origin:top center;
-	-webkit-animation-name: swing;
-	        animation-name: swing;
+	transform-origin:top center;
+	animation-name: swing;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes tada {
-	from {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
-	}
-	10%,20% {
-				-webkit-transform:scale3d(.9,.9,.9) rotate3d(0,0,1,-3deg);
-				        transform:scale3d(.9,.9,.9) rotate3d(0,0,1,-3deg);
-	}
-	30%,50%,70%,90% {
-				-webkit-transform:scale3d(1.1,1.1,1.1) rotate3d(0,0,1,3deg);
-				        transform:scale3d(1.1,1.1,1.1) rotate3d(0,0,1,3deg);
-	}
-	40%,60%,80% {
-				-webkit-transform:scale3d(1.1,1.1,1.1) rotate3d(0,0,1,-3deg);
-				        transform:scale3d(1.1,1.1,1.1) rotate3d(0,0,1,-3deg);
-	}
-	100% {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
-	}
-}
 @keyframes tada {
 	from {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
+			transform:scale3d(1,1,1);
 	}
 	10%,20% {
-				-webkit-transform:scale3d(.9,.9,.9) rotate3d(0,0,1,-3deg);
-				        transform:scale3d(.9,.9,.9) rotate3d(0,0,1,-3deg);
+			transform:scale3d(.9,.9,.9) rotate3d(0,0,1,-3deg);
 	}
 	30%,50%,70%,90% {
-				-webkit-transform:scale3d(1.1,1.1,1.1) rotate3d(0,0,1,3deg);
-				        transform:scale3d(1.1,1.1,1.1) rotate3d(0,0,1,3deg);
+			transform:scale3d(1.1,1.1,1.1) rotate3d(0,0,1,3deg);
 	}
 	40%,60%,80% {
-				-webkit-transform:scale3d(1.1,1.1,1.1) rotate3d(0,0,1,-3deg);
-				        transform:scale3d(1.1,1.1,1.1) rotate3d(0,0,1,-3deg);
+			transform:scale3d(1.1,1.1,1.1) rotate3d(0,0,1,-3deg);
 	}
 	100% {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
+			transform:scale3d(1,1,1);
 	}
 }
 .tada {
-	-webkit-animation-name: tada;
-	        animation-name: tada;
+	animation-name: tada;
 }
 /*----------------------------------------------------------------------------*/
 /* originally authored by Nick Pettit - https://github.com/nickpettit/glide */
-@-webkit-keyframes wobble {
-	from {
-				-webkit-transform:none;
-				        transform:none;
-	}
-	15% {
-				-webkit-transform:translate3d(-25%,0,0) rotate3d(0,0,1,-5deg);
-				        transform:translate3d(-25%,0,0) rotate3d(0,0,1,-5deg);
-	}
-	30% {
-				-webkit-transform:translate3d(20%,0,0) rotate3d(0,0,1,3deg);
-				        transform:translate3d(20%,0,0) rotate3d(0,0,1,3deg);
-	}
-	45% {
-				-webkit-transform:translate3d(-15%,0,0) rotate3d(0,0,1,-3deg);
-				        transform:translate3d(-15%,0,0) rotate3d(0,0,1,-3deg);
-	}
-	60% {
-				-webkit-transform:translate3d(10%,0,0) rotate3d(0,0,1,2deg);
-				        transform:translate3d(10%,0,0) rotate3d(0,0,1,2deg);
-	}
-	75% {
-				-webkit-transform:translate3d(-5%,0,0) rotate3d(0,0,1,-1deg);
-				        transform:translate3d(-5%,0,0) rotate3d(0,0,1,-1deg);
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-	}
-}
 @keyframes wobble {
 	from {
-				-webkit-transform:none;
-				        transform:none;
+			transform:none;
 	}
 	15% {
-				-webkit-transform:translate3d(-25%,0,0) rotate3d(0,0,1,-5deg);
-				        transform:translate3d(-25%,0,0) rotate3d(0,0,1,-5deg);
+			transform:translate3d(-25%,0,0) rotate3d(0,0,1,-5deg);
 	}
 	30% {
-				-webkit-transform:translate3d(20%,0,0) rotate3d(0,0,1,3deg);
-				        transform:translate3d(20%,0,0) rotate3d(0,0,1,3deg);
+			transform:translate3d(20%,0,0) rotate3d(0,0,1,3deg);
 	}
 	45% {
-				-webkit-transform:translate3d(-15%,0,0) rotate3d(0,0,1,-3deg);
-				        transform:translate3d(-15%,0,0) rotate3d(0,0,1,-3deg);
+			transform:translate3d(-15%,0,0) rotate3d(0,0,1,-3deg);
 	}
 	60% {
-				-webkit-transform:translate3d(10%,0,0) rotate3d(0,0,1,2deg);
-				        transform:translate3d(10%,0,0) rotate3d(0,0,1,2deg);
+			transform:translate3d(10%,0,0) rotate3d(0,0,1,2deg);
 	}
 	75% {
-				-webkit-transform:translate3d(-5%,0,0) rotate3d(0,0,1,-1deg);
-				        transform:translate3d(-5%,0,0) rotate3d(0,0,1,-1deg);
+			transform:translate3d(-5%,0,0) rotate3d(0,0,1,-1deg);
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
+			transform:none;
 	}
 }
 .wobble {
-	-webkit-animation-name: wobble;
-	        animation-name: wobble;
+	animation-name: wobble;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes jello {
-	from,11.1%,100% {
-				-webkit-transform:none;
-				        transform:none;
-	}
-	22.2% {
-				-webkit-transform:skewX(-12.5deg) skewY(-12.5deg);
-				        transform:skewX(-12.5deg) skewY(-12.5deg);
-	}
-	33.3% {
-				-webkit-transform:skewX(6.25deg) skewY(6.25deg);
-				        transform:skewX(6.25deg) skewY(6.25deg);
-	}
-	44.4% {
-				-webkit-transform:skewX(-3.125deg) skewY(-3.125deg);
-				        transform:skewX(-3.125deg) skewY(-3.125deg);
-	}
-	55.5% {
-				-webkit-transform:skewX(1.5625deg) skewY(1.5625deg);
-				        transform:skewX(1.5625deg) skewY(1.5625deg);
-	}
-	66.6% {
-				-webkit-transform:skewX(-.78125deg) skewY(-.78125deg);
-				        transform:skewX(-.78125deg) skewY(-.78125deg);
-	}
-	77.7% {
-				-webkit-transform:skewX(.390625deg) skewY(.390625deg);
-				        transform:skewX(.390625deg) skewY(.390625deg);
-	}
-	88.8% {
-				-webkit-transform:skewX(-.1953125deg) skewY(-.1953125deg);
-				        transform:skewX(-.1953125deg) skewY(-.1953125deg);
-	}
-}
 @keyframes jello {
 	from,11.1%,100% {
-				-webkit-transform:none;
-				        transform:none;
+			transform:none;
 	}
 	22.2% {
-				-webkit-transform:skewX(-12.5deg) skewY(-12.5deg);
-				        transform:skewX(-12.5deg) skewY(-12.5deg);
+			transform:skewX(-12.5deg) skewY(-12.5deg);
 	}
 	33.3% {
-				-webkit-transform:skewX(6.25deg) skewY(6.25deg);
-				        transform:skewX(6.25deg) skewY(6.25deg);
+			transform:skewX(6.25deg) skewY(6.25deg);
 	}
 	44.4% {
-				-webkit-transform:skewX(-3.125deg) skewY(-3.125deg);
-				        transform:skewX(-3.125deg) skewY(-3.125deg);
+			transform:skewX(-3.125deg) skewY(-3.125deg);
 	}
 	55.5% {
-				-webkit-transform:skewX(1.5625deg) skewY(1.5625deg);
-				        transform:skewX(1.5625deg) skewY(1.5625deg);
+			transform:skewX(1.5625deg) skewY(1.5625deg);
 	}
 	66.6% {
-				-webkit-transform:skewX(-.78125deg) skewY(-.78125deg);
-				        transform:skewX(-.78125deg) skewY(-.78125deg);
+			transform:skewX(-.78125deg) skewY(-.78125deg);
 	}
 	77.7% {
-				-webkit-transform:skewX(.390625deg) skewY(.390625deg);
-				        transform:skewX(.390625deg) skewY(.390625deg);
+			transform:skewX(.390625deg) skewY(.390625deg);
 	}
 	88.8% {
-				-webkit-transform:skewX(-.1953125deg) skewY(-.1953125deg);
-				        transform:skewX(-.1953125deg) skewY(-.1953125deg);
+			transform:skewX(-.1953125deg) skewY(-.1953125deg);
 	}
 }
 .jello {
-	-webkit-transform-origin:center;
-	    -ms-transform-origin:center;
-	        transform-origin:center;
-	-webkit-animation-name: jello;
-	        animation-name: jello;
+	transform-origin:center;
+	animation-name: jello;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounceIn {
-	from,20%,40%,60%,80%,100% {
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-	}
-	0% {
-				-webkit-transform:scale3d(.3,.3,.3);
-				        transform:scale3d(.3,.3,.3);
-				opacity:0;
-	}
-	20% {
-				-webkit-transform:scale3d(1.1,1.1,1.1);
-				        transform:scale3d(1.1,1.1,1.1);
-	}
-	40% {
-				-webkit-transform:scale3d(.9,.9,.9);
-				        transform:scale3d(.9,.9,.9);
-	}
-	60% {
-				-webkit-transform:scale3d(1.03,1.03,1.03);
-				        transform:scale3d(1.03,1.03,1.03);
-				opacity:1;
-	}
-	80% {
-				-webkit-transform:scale3d(.97,.97,.97);
-				        transform:scale3d(.97,.97,.97);
-	}
-	100% {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
-				opacity:1;
-	}
-}
 @keyframes bounceIn {
 	from,20%,40%,60%,80%,100% {
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
+			animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
 	}
 	0% {
-				-webkit-transform:scale3d(.3,.3,.3);
-				        transform:scale3d(.3,.3,.3);
-				opacity:0;
+			transform:scale3d(.3,.3,.3);
+			opacity:0;
 	}
 	20% {
-				-webkit-transform:scale3d(1.1,1.1,1.1);
-				        transform:scale3d(1.1,1.1,1.1);
+			transform:scale3d(1.1,1.1,1.1);
 	}
 	40% {
-				-webkit-transform:scale3d(.9,.9,.9);
-				        transform:scale3d(.9,.9,.9);
+			transform:scale3d(.9,.9,.9);
 	}
 	60% {
-				-webkit-transform:scale3d(1.03,1.03,1.03);
-				        transform:scale3d(1.03,1.03,1.03);
-				opacity:1;
+			transform:scale3d(1.03,1.03,1.03);
+			opacity:1;
 	}
 	80% {
-				-webkit-transform:scale3d(.97,.97,.97);
-				        transform:scale3d(.97,.97,.97);
+			transform:scale3d(.97,.97,.97);
 	}
 	100% {
-				-webkit-transform:scale3d(1,1,1);
-				        transform:scale3d(1,1,1);
-				opacity:1;
+			transform:scale3d(1,1,1);
+			opacity:1;
 	}
 }
 .bounceIn {
-	-webkit-animation-name: bounceIn;
-	        animation-name: bounceIn;
+	animation-name: bounceIn;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounceInDown {
-	from,60%,75%,90%,100% {
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-	}
-	0% {
-				-webkit-transform:translate3d(0,-3000px,0);
-				        transform:translate3d(0,-3000px,0);
-				opacity:0;
-	}
-	60% {
-				-webkit-transform:translate3d(0,25px,0);
-				        transform:translate3d(0,25px,0);
-				opacity:1;
-	}
-	75% {
-				-webkit-transform:translate3d(0,-10px,0);
-				        transform:translate3d(0,-10px,0);
-	}
-	90% {
-				-webkit-transform:translate3d(0,5px,0);
-				        transform:translate3d(0,5px,0);
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-	}
-}
 @keyframes bounceInDown {
 	from,60%,75%,90%,100% {
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
+			animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
 	}
 	0% {
-				-webkit-transform:translate3d(0,-3000px,0);
-				        transform:translate3d(0,-3000px,0);
-				opacity:0;
+			transform:translate3d(0,-3000px,0);
+			opacity:0;
 	}
 	60% {
-				-webkit-transform:translate3d(0,25px,0);
-				        transform:translate3d(0,25px,0);
-				opacity:1;
+			transform:translate3d(0,25px,0);
+			opacity:1;
 	}
 	75% {
-				-webkit-transform:translate3d(0,-10px,0);
-				        transform:translate3d(0,-10px,0);
+			transform:translate3d(0,-10px,0);
 	}
 	90% {
-				-webkit-transform:translate3d(0,5px,0);
-				        transform:translate3d(0,5px,0);
+			transform:translate3d(0,5px,0);
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
+			transform:none;
 	}
 }
 .bounceInDown {
-	-webkit-animation-name: bounceInDown;
-	        animation-name: bounceInDown;
+	animation-name: bounceInDown;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounceInLeft {
-	from,60%,75%,90%,100% {
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-	}
-	0% {
-				-webkit-transform:translate3d(-3000px,0,0);
-				        transform:translate3d(-3000px,0,0);
-				opacity:0;
-	}
-	60% {
-				-webkit-transform:translate3d(25px,0,0);
-				        transform:translate3d(25px,0,0);
-				opacity:1;
-	}
-	75% {
-				-webkit-transform:translate3d(-10px,0,0);
-				        transform:translate3d(-10px,0,0);
-	}
-	90% {
-				-webkit-transform:translate3d(5px,0,0);
-				        transform:translate3d(5px,0,0);
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-	}
-}
 @keyframes bounceInLeft {
 	from,60%,75%,90%,100% {
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
+			animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
 	}
 	0% {
-				-webkit-transform:translate3d(-3000px,0,0);
-				        transform:translate3d(-3000px,0,0);
-				opacity:0;
+			transform:translate3d(-3000px,0,0);
+			opacity:0;
 	}
 	60% {
-				-webkit-transform:translate3d(25px,0,0);
-				        transform:translate3d(25px,0,0);
-				opacity:1;
+			transform:translate3d(25px,0,0);
+			opacity:1;
 	}
 	75% {
-				-webkit-transform:translate3d(-10px,0,0);
-				        transform:translate3d(-10px,0,0);
+			transform:translate3d(-10px,0,0);
 	}
 	90% {
-				-webkit-transform:translate3d(5px,0,0);
-				        transform:translate3d(5px,0,0);
+			transform:translate3d(5px,0,0);
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
+			transform:none;
 	}
 }
 .bounceInLeft {
-	-webkit-animation-name: bounceInLeft;
-	        animation-name: bounceInLeft;
+	animation-name: bounceInLeft;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounceInRight {
-	from,60%,75%,90%,100% {
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-	}
-	from {
-				-webkit-transform:translate3d(3000px,0,0);
-				        transform:translate3d(3000px,0,0);
-				opacity:0;
-	}
-	60% {
-				-webkit-transform:translate3d(-25px,0,0);
-				        transform:translate3d(-25px,0,0);
-				opacity:1;
-	}
-	75% {
-				-webkit-transform:translate3d(10px,0,0);
-				        transform:translate3d(10px,0,0);
-	}
-	90% {
-				-webkit-transform:translate3d(-5px,0,0);
-				        transform:translate3d(-5px,0,0);
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-	}
-}
 @keyframes bounceInRight {
 	from,60%,75%,90%,100% {
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
+			animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
 	}
 	from {
-				-webkit-transform:translate3d(3000px,0,0);
-				        transform:translate3d(3000px,0,0);
-				opacity:0;
+			transform:translate3d(3000px,0,0);
+			opacity:0;
 	}
 	60% {
-				-webkit-transform:translate3d(-25px,0,0);
-				        transform:translate3d(-25px,0,0);
-				opacity:1;
+			transform:translate3d(-25px,0,0);
+			opacity:1;
 	}
 	75% {
-				-webkit-transform:translate3d(10px,0,0);
-				        transform:translate3d(10px,0,0);
+			transform:translate3d(10px,0,0);
 	}
 	90% {
-				-webkit-transform:translate3d(-5px,0,0);
-				        transform:translate3d(-5px,0,0);
+			transform:translate3d(-5px,0,0);
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
+			transform:none;
 	}
 }
 .bounceInRight {
-	-webkit-animation-name: bounceInRight;
-	        animation-name: bounceInRight;
+	animation-name:bounceInRight;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounceInUp {
-	from,60%,75%,90%,100% {
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-	}
-	from {
-				-webkit-transform:translate3d(0,3000px,0);
-				        transform:translate3d(0,3000px,0);
-				opacity:0;
-	}
-	60% {
-				-webkit-transform:translate3d(0,-20px,0);
-				        transform:translate3d(0,-20px,0);
-				opacity:1;
-	}
-	75% {
-				-webkit-transform:translate3d(0,10px,0);
-				        transform:translate3d(0,10px,0);
-	}
-	90% {
-				-webkit-transform:translate3d(0,-5px,0);
-				        transform:translate3d(0,-5px,0);
-	}
-	100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-	}
-}
 @keyframes bounceInUp {
 	from,60%,75%,90%,100% {
-				-webkit-animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
-				        animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
+			animation-timing-function:cubic-bezier(.215,.610,.355,1.000);
 	}
 	from {
-				-webkit-transform:translate3d(0,3000px,0);
-				        transform:translate3d(0,3000px,0);
-				opacity:0;
+			transform:translate3d(0,3000px,0);
+			opacity:0;
 	}
 	60% {
-				-webkit-transform:translate3d(0,-20px,0);
-				        transform:translate3d(0,-20px,0);
-				opacity:1;
+			transform:translate3d(0,-20px,0);
+			opacity:1;
 	}
 	75% {
-				-webkit-transform:translate3d(0,10px,0);
-				        transform:translate3d(0,10px,0);
+			transform:translate3d(0,10px,0);
 	}
 	90% {
-				-webkit-transform:translate3d(0,-5px,0);
-				        transform:translate3d(0,-5px,0);
+			transform:translate3d(0,-5px,0);
 	}
 	100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
+			transform:translate3d(0,0,0);
 	}
 }
 .bounceInUp {
-	-webkit-animation-name: bounceInUp;
-	        animation-name: bounceInUp;
+	animation-name:bounceInUp;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounceOut {
-	20% {
-				-webkit-transform:scale3d(.9,.9,.9);
-				        transform:scale3d(.9,.9,.9);
-	}
-	50%,55% {
-				-webkit-transform:scale3d(1.1,1.1,1.1);
-				        transform:scale3d(1.1,1.1,1.1);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:scale3d(.3,.3,.3);
-				        transform:scale3d(.3,.3,.3);
-				opacity:0;
-	}
-}
 @keyframes bounceOut {
 	20% {
-				-webkit-transform:scale3d(.9,.9,.9);
-				        transform:scale3d(.9,.9,.9);
+			transform:scale3d(.9,.9,.9);
 	}
 	50%,55% {
-				-webkit-transform:scale3d(1.1,1.1,1.1);
-				        transform:scale3d(1.1,1.1,1.1);
-				opacity:1;
+			transform:scale3d(1.1,1.1,1.1);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:scale3d(.3,.3,.3);
-				        transform:scale3d(.3,.3,.3);
-				opacity:0;
+			transform:scale3d(.3,.3,.3);
+			opacity: 0;
 	}
 }
 .bounceOut {
-	-webkit-animation-name: bounceOut;
-	        animation-name: bounceOut;
+	animation-name:bounceOut;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounceOutDown {
-	20% {
-				-webkit-transform:translate3d(0,10px,0);
-				        transform:translate3d(0,10px,0);
-	}
-	40%,45% {
-				-webkit-transform:translate3d(0,-20px,0);
-				        transform:translate3d(0,-20px,0);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(0,2000px,0);
-				        transform:translate3d(0,2000px,0);
-				opacity:0;
-	}
-}
 @keyframes bounceOutDown {
 	20% {
-				-webkit-transform:translate3d(0,10px,0);
-				        transform:translate3d(0,10px,0);
+			transform:translate3d(0,10px,0);
 	}
 	40%,45% {
-				-webkit-transform:translate3d(0,-20px,0);
-				        transform:translate3d(0,-20px,0);
-				opacity:1;
+			transform:translate3d(0,-20px,0);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(0,2000px,0);
-				        transform:translate3d(0,2000px,0);
-				opacity:0;
+			transform:translate3d(0,2000px,0);
+			opacity: 0;
 	}
 }
 .bounceOutDown {
-	-webkit-animation-name: bounceOutDown;
-	        animation-name: bounceOutDown;
+	animation-name:bounceOutDown;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounceOutLeft {
-	20% {
-				-webkit-transform:translate3d(20px,0,0);
-				        transform:translate3d(20px,0,0);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(-2000px,0,0);
-				        transform:translate3d(-2000px,0,0);
-				opacity:0;
-	}
-}
 @keyframes bounceOutLeft {
 	20% {
-				-webkit-transform:translate3d(20px,0,0);
-				        transform:translate3d(20px,0,0);
-				opacity:1;
+			transform:translate3d(20px,0,0);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(-2000px,0,0);
-				        transform:translate3d(-2000px,0,0);
-				opacity:0;
+			transform:translate3d(-2000px,0,0);
+			opacity: 0;
 	}
 }
 .bounceOutLeft {
-	-webkit-animation-name: bounceOutLeft;
-	        animation-name: bounceOutLeft;
+	animation-name:bounceOutLeft;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounceOutRight {
-	20% {
-				-webkit-transform:translate3d(-20px,0,0);
-				        transform:translate3d(-20px,0,0);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(2000px,0,0);
-				        transform:translate3d(2000px,0,0);
-				opacity:0;
-	}
-}
 @keyframes bounceOutRight {
 	20% {
-				-webkit-transform:translate3d(-20px,0,0);
-				        transform:translate3d(-20px,0,0);
-				opacity:1;
+			transform:translate3d(-20px,0,0);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(2000px,0,0);
-				        transform:translate3d(2000px,0,0);
-				opacity:0;
+			transform:translate3d(2000px,0,0);
+			opacity: 0;
 	}
 }
 .bounceOutRight {
-	-webkit-animation-name: bounceOutRight;
-	        animation-name: bounceOutRight;
+	animation-name:bounceOutRight;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bounceOutUp {
-	20% {
-				-webkit-transform:translate3d(0,-10px,0);
-				        transform:translate3d(0,-10px,0);
-	}
-	40%,45% {
-				-webkit-transform:translate3d(0,20px,0);
-				        transform:translate3d(0,20px,0);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(0,-2000px,0);
-				        transform:translate3d(0,-2000px,0);
-				opacity:0;
-	}
-}
 @keyframes bounceOutUp {
 	20% {
-				-webkit-transform:translate3d(0,-10px,0);
-				        transform:translate3d(0,-10px,0);
+			transform:translate3d(0,-10px,0);
 	}
 	40%,45% {
-				-webkit-transform:translate3d(0,20px,0);
-				        transform:translate3d(0,20px,0);
-				opacity:1;
+			transform:translate3d(0,20px,0);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(0,-2000px,0);
-				        transform:translate3d(0,-2000px,0);
-				opacity:0;
+			transform:translate3d(0,-2000px,0);
+			opacity: 0;
 	}
 }
 .bounceOutUp {
-	-webkit-animation-name:bounceOutUp;
-	        animation-name:bounceOutUp;
-}
-@-webkit-keyframes fadeIn {
-	from {
-				opacity:0;
-	}
-	100% {
-				opacity:1;
-	}
+	animation-name:bounceOutUp;
 }
 @keyframes fadeIn {
 	from {
-				opacity:0;
+			opacity:0;
 	}
 	100% {
-				opacity:1;
+			opacity:1;
 	}
 }
 .fadeIn {
-	-webkit-animation-name:fadeIn;
-	        animation-name:fadeIn;
-}
-@-webkit-keyframes fadeInDown {
-	from {
-				-webkit-transform:translate3d(0,-100%,0);
-				        transform:translate3d(0,-100%,0);
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
-	}
+	animation-name:fadeIn;
 }
 @keyframes fadeInDown {
 	from {
-				-webkit-transform:translate3d(0,-100%,0);
-				        transform:translate3d(0,-100%,0);
-				opacity:0;
+			transform:translate3d(0,-100%,0);
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
+			transform:none;
+			opacity:1;
 	}
 }
 .fadeInDown {
-	-webkit-animation-name:fadeInDown;
-	        animation-name:fadeInDown;
-}
-@-webkit-keyframes fadeInDownBig {
-	from {
-				-webkit-transform:translate3d(0,-2000px,0);
-				        transform:translate3d(0,-2000px,0);
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
-	}
+	animation-name:fadeInDown;
 }
 @keyframes fadeInDownBig {
 	from {
-				-webkit-transform:translate3d(0,-2000px,0);
-				        transform:translate3d(0,-2000px,0);
-				opacity:0;
+			transform:translate3d(0,-2000px,0);
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
+			transform:none;
+			opacity:1;
 	}
 }
 .fadeInDownBig {
-	-webkit-animation-name:fadeInDownBig;
-	        animation-name:fadeInDownBig;
-}
-@-webkit-keyframes fadeInLeft {
-	from {
-				-webkit-transform:translate3d(-100%,0,0);
-				        transform:translate3d(-100%,0,0);
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
-	}
+	animation-name:fadeInDownBig;
 }
 @keyframes fadeInLeft {
 	from {
-				-webkit-transform:translate3d(-100%,0,0);
-				        transform:translate3d(-100%,0,0);
-				opacity:0;
+			transform:translate3d(-100%,0,0);
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
+			transform:none;
+			opacity:1;
 	}
 }
 .fadeInLeft {
-	-webkit-animation-name:fadeInLeft;
-	        animation-name:fadeInLeft;
-}
-@-webkit-keyframes fadeInLeftBig {
-	from {
-				-webkit-transform:translate3d(-2000px,0,0);
-				        transform:translate3d(-2000px,0,0);
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
-	}
+	animation-name:fadeInLeft;
 }
 @keyframes fadeInLeftBig {
 	from {
-				-webkit-transform:translate3d(-2000px,0,0);
-				        transform:translate3d(-2000px,0,0);
-				opacity:0;
+			transform:translate3d(-2000px,0,0);
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
+			transform:none;
+			opacity:1;
 	}
 }
 .fadeInLeftBig {
-	-webkit-animation-name:fadeInLeftBig;
-	        animation-name:fadeInLeftBig;
-}
-@-webkit-keyframes fadeInRight {
-	from {
-				-webkit-transform:translate3d(100%,0,0);
-				        transform:translate3d(100%,0,0);
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
-	}
+	animation-name:fadeInLeftBig;
 }
 @keyframes fadeInRight {
 	from {
-				-webkit-transform:translate3d(100%,0,0);
-				        transform:translate3d(100%,0,0);
-				opacity:0;
+			transform:translate3d(100%,0,0);
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
+			transform:none;
+			opacity:1;
 	}
 }
 .fadeInRight {
-	-webkit-animation-name:fadeInRight;
-	        animation-name:fadeInRight;
-}
-@-webkit-keyframes fadeInRightBig {
-	from {
-				-webkit-transform:translate3d(2000px,0,0);
-				        transform:translate3d(2000px,0,0);
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
-	}
+	animation-name:fadeInRight;
 }
 @keyframes fadeInRightBig {
 	from {
-				-webkit-transform:translate3d(2000px,0,0);
-				        transform:translate3d(2000px,0,0);
-				opacity:0;
+			transform:translate3d(2000px,0,0);
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
+			transform:none;
+			opacity:1;
 	}
 }
 .fadeInRightBig {
-	-webkit-animation-name:fadeInRightBig;
-	        animation-name:fadeInRightBig;
-}
-@-webkit-keyframes fadeInUp {
-	from {
-				-webkit-transform:translate3d(0,100%,0);
-				        transform:translate3d(0,100%,0);
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
-	}
+	animation-name:fadeInRightBig;
 }
 @keyframes fadeInUp {
 	from {
-				-webkit-transform:translate3d(0,100%,0);
-				        transform:translate3d(0,100%,0);
-				opacity:0;
+			transform:translate3d(0,100%,0);
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
+			transform:none;
+			opacity:1;
 	}
 }
 .fadeInUp {
-	-webkit-animation-name:fadeInUp;
-	        animation-name:fadeInUp;
-}
-@-webkit-keyframes fadeInUpBig {
-	from {
-				-webkit-transform:translate3d(0,2000px,0);
-				        transform:translate3d(0,2000px,0);
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
-	}
+	animation-name:fadeInUp;
 }
 @keyframes fadeInUpBig {
 	from {
-				-webkit-transform:translate3d(0,2000px,0);
-				        transform:translate3d(0,2000px,0);
-				opacity:0;
+			transform:translate3d(0,2000px,0);
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
+			transform:none;
+			opacity:1;
 	}
 }
 .fadeInUpBig {
-	-webkit-animation-name:fadeInUpBig;
-	        animation-name:fadeInUpBig;
-}
-@-webkit-keyframes fadeOut {
-	from {
-				opacity:1;
-	}
-	100% {
-				opacity:0;
-	}
+	animation-name:fadeInUpBig;
 }
 @keyframes fadeOut {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				opacity:0;
+			opacity:0;
 	}
 }
 .fadeOut {
-	-webkit-animation-name:fadeOut;
-	        animation-name:fadeOut;
-}
-@-webkit-keyframes fadeOutDown {
-	from {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(0,100%,0);
-				        transform:translate3d(0,100%,0);
-				opacity:0;
-	}
+	animation-name:fadeOut;
 }
 @keyframes fadeOutDown {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(0,100%,0);
-				        transform:translate3d(0,100%,0);
-				opacity:0;
+			transform:translate3d(0,100%,0);
+			opacity:0;
 	}
 }
 .fadeOutDown {
-	-webkit-animation-name:fadeOutDown;
-	        animation-name:fadeOutDown;
-}
-@-webkit-keyframes fadeOutDownBig {
-	from {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(0,2000px,0);
-				        transform:translate3d(0,2000px,0);
-				opacity:0;
-	}
+	animation-name:fadeOutDown;
 }
 @keyframes fadeOutDownBig {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(0,2000px,0);
-				        transform:translate3d(0,2000px,0);
-				opacity:0;
+			transform:translate3d(0,2000px,0);
+			opacity:0;
 	}
 }
 .fadeOutDownBig {
-	-webkit-animation-name:fadeOutDownBig;
-	        animation-name:fadeOutDownBig;
-}
-@-webkit-keyframes fadeOutLeft {
-	from {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(-100%,0,0);
-				        transform:translate3d(-100%,0,0);
-				opacity:0;
-	}
+	animation-name:fadeOutDownBig;
 }
 @keyframes fadeOutLeft {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(-100%,0,0);
-				        transform:translate3d(-100%,0,0);
-				opacity:0;
+			transform:translate3d(-100%,0,0);
+			opacity:0;
 	}
 }
 .fadeOutLeft {
-	-webkit-animation-name:fadeOutLeft;
-	        animation-name:fadeOutLeft;
-}
-@-webkit-keyframes fadeOutLeftBig {
-	from {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(-2000px,0,0);
-				        transform:translate3d(-2000px,0,0);
-				opacity:0;
-	}
+	animation-name:fadeOutLeft;
 }
 @keyframes fadeOutLeftBig {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(-2000px,0,0);
-				        transform:translate3d(-2000px,0,0);
-				opacity:0;
+			transform:translate3d(-2000px,0,0);
+			opacity:0;
 	}
 }
 .fadeOutLeftBig {
-	-webkit-animation-name:fadeOutLeftBig;
-	        animation-name:fadeOutLeftBig;
-}
-@-webkit-keyframes fadeOutRight {
-	from {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(100%,0,0);
-				        transform:translate3d(100%,0,0);
-				opacity:0;
-	}
+	animation-name:fadeOutLeftBig;
 }
 @keyframes fadeOutRight {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(100%,0,0);
-				        transform:translate3d(100%,0,0);
-				opacity:0;
+			transform:translate3d(100%,0,0);
+			opacity:0;
 	}
 }
 .fadeOutRight {
-	-webkit-animation-name:fadeOutRight;
-	        animation-name:fadeOutRight;
-}
-@-webkit-keyframes fadeOutRightBig {
-	from {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(2000px,0,0);
-				        transform:translate3d(2000px,0,0);
-				opacity:0;
-	}
+	animation-name:fadeOutRight;
 }
 @keyframes fadeOutRightBig {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(2000px,0,0);
-				        transform:translate3d(2000px,0,0);
-				opacity:0;
+			transform:translate3d(2000px,0,0);
+			opacity:0;
 	}
 }
 .fadeOutRightBig {
-	-webkit-animation-name:fadeOutRightBig;
-	        animation-name:fadeOutRightBig;
-}
-@-webkit-keyframes fadeOutUp {
-	from {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(0,-100%,0);
-				        transform:translate3d(0,-100%,0);
-				opacity:0;
-	}
+	animation-name:fadeOutRightBig;
 }
 @keyframes fadeOutUp {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(0,-100%,0);
-				        transform:translate3d(0,-100%,0);
-				opacity:0;
+			transform:translate3d(0,-100%,0);
+			opacity:0;
 	}
 }
 .fadeOutUp {
-	-webkit-animation-name:fadeOutUp;
-	        animation-name:fadeOutUp;
-}
-@-webkit-keyframes fadeOutUpBig {
-	from {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(0,-2000px,0);
-				        transform:translate3d(0,-2000px,0);
-				opacity:0;
-	}
+	animation-name:fadeOutUp;
 }
 @keyframes fadeOutUpBig {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(0,-2000px,0);
-				        transform:translate3d(0,-2000px,0);
-				opacity:0;
+			transform:translate3d(0,-2000px,0);
+			opacity:0;
 	}
 }
 .fadeOutUpBig {
-	-webkit-animation-name:fadeOutUpBig;
-	        animation-name:fadeOutUpBig;
-}
-@-webkit-keyframes flip {
-	from {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,-360deg);
-				        transform:perspective(400px) rotate3d(0,1,0,-360deg);
-				-webkit-animation-timing-function:ease-out;
-				        animation-timing-function:ease-out;
-	}
-	40% {
-				-webkit-transform:perspective(400px) translate3d(0,0,150px) rotate3d(0,1,0,-190deg);
-				        transform:perspective(400px) translate3d(0,0,150px) rotate3d(0,1,0,-190deg);
-				-webkit-animation-timing-function:ease-out;
-				        animation-timing-function:ease-out;
-	}
-	50% {
-				-webkit-transform:perspective(400px) translate3d(0,0,150px) rotate3d(0,1,0,-170deg);
-				        transform:perspective(400px) translate3d(0,0,150px) rotate3d(0,1,0,-170deg);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-	80% {
-				-webkit-transform:perspective(400px) scale3d(.95,.95,.95);
-				        transform:perspective(400px) scale3d(.95,.95,.95);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-	100% {
-				-webkit-transform:perspective(400px);
-				        transform:perspective(400px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
+	animation-name:fadeOutUpBig;
 }
 @keyframes flip {
 	from {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,-360deg);
-				        transform:perspective(400px) rotate3d(0,1,0,-360deg);
-				-webkit-animation-timing-function:ease-out;
-				        animation-timing-function:ease-out;
+			transform:perspective(400px) rotate3d(0,1,0,-360deg);
+			animation-timing-function:ease-out;
 	}
 	40% {
-				-webkit-transform:perspective(400px) translate3d(0,0,150px) rotate3d(0,1,0,-190deg);
-				        transform:perspective(400px) translate3d(0,0,150px) rotate3d(0,1,0,-190deg);
-				-webkit-animation-timing-function:ease-out;
-				        animation-timing-function:ease-out;
+			transform:perspective(400px) translate3d(0,0,150px) rotate3d(0,1,0,-190deg);
+			animation-timing-function:ease-out;
 	}
 	50% {
-				-webkit-transform:perspective(400px) translate3d(0,0,150px) rotate3d(0,1,0,-170deg);
-				        transform:perspective(400px) translate3d(0,0,150px) rotate3d(0,1,0,-170deg);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:perspective(400px) translate3d(0,0,150px) rotate3d(0,1,0,-170deg);
+			animation-timing-function:ease-in-out;
 	}
 	80% {
-				-webkit-transform:perspective(400px) scale3d(.95,.95,.95);
-				        transform:perspective(400px) scale3d(.95,.95,.95);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:perspective(400px) scale3d(.95,.95,.95);
+			animation-timing-function:ease-in-out;
 	}
 	100% {
-				-webkit-transform:perspective(400px);
-				        transform:perspective(400px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:perspective(400px);
+			animation-timing-function:ease-in-out;
 	}
 }
 .animated.flip {
-	-webkit-animation-name:flip;
-	        animation-name:flip;
-	-webkit-backface-visibility:visible;
-	        backface-visibility:visible;
-}
-@-webkit-keyframes flipInX {
-	from {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,90deg);
-				        transform:perspective(400px) rotate3d(1,0,0,90deg);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-				opacity:0;
-	}
-	40% {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,-20deg);
-				        transform:perspective(400px) rotate3d(1,0,0,-20deg);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-	60% {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,10deg);
-				        transform:perspective(400px) rotate3d(1,0,0,10deg);
-				opacity:1;
-	}
-	80% {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,-5deg);
-				        transform:perspective(400px) rotate3d(1,0,0,-5deg);
-	}
-	100% {
-				-webkit-transform:perspective(400px);
-				        transform:perspective(400px);
-	}
+	animation-name:flip;
+	backface-visibility:visible;
 }
 @keyframes flipInX {
 	from {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,90deg);
-				        transform:perspective(400px) rotate3d(1,0,0,90deg);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-				opacity:0;
+			transform:perspective(400px) rotate3d(1,0,0,90deg);
+			animation-timing-function:ease-in-out;
+			opacity:0;
 	}
 	40% {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,-20deg);
-				        transform:perspective(400px) rotate3d(1,0,0,-20deg);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:perspective(400px) rotate3d(1,0,0,-20deg);
+			animation-timing-function:ease-in-out;
 	}
 	60% {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,10deg);
-				        transform:perspective(400px) rotate3d(1,0,0,10deg);
-				opacity:1;
+			transform:perspective(400px) rotate3d(1,0,0,10deg);
+			opacity:1;
 	}
 	80% {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,-5deg);
-				        transform:perspective(400px) rotate3d(1,0,0,-5deg);
+			transform:perspective(400px) rotate3d(1,0,0,-5deg);
 	}
 	100% {
-				-webkit-transform:perspective(400px);
-				        transform:perspective(400px);
+			transform:perspective(400px);
 	}
 }
 .flipInX {
-	-webkit-animation-name:flipInX;
-	        animation-name:flipInX;
-	-webkit-backface-visibility:visible !important;
-	        backface-visibility:visible !important;
-}
-@-webkit-keyframes flipInY {
-	from {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,90deg);
-				        transform:perspective(400px) rotate3d(0,1,0,90deg);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-				opacity:0;
-	}
-	40% {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,-20deg);
-				        transform:perspective(400px) rotate3d(0,1,0,-20deg);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-	60% {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,10deg);
-				        transform:perspective(400px) rotate3d(0,1,0,10deg);
-				opacity:1;
-	}
-	80% {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,-5deg);
-				        transform:perspective(400px) rotate3d(0,1,0,-5deg);
-	}
-	100% {
-				-webkit-transform:perspective(400px);
-				        transform:perspective(400px);
-	}
+	animation-name:flipInX;
+	backface-visibility:visible !important;
 }
 @keyframes flipInY {
 	from {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,90deg);
-				        transform:perspective(400px) rotate3d(0,1,0,90deg);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-				opacity:0;
+			transform:perspective(400px) rotate3d(0,1,0,90deg);
+			animation-timing-function:ease-in-out;
+			opacity:0;
 	}
 	40% {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,-20deg);
-				        transform:perspective(400px) rotate3d(0,1,0,-20deg);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:perspective(400px) rotate3d(0,1,0,-20deg);
+			animation-timing-function:ease-in-out;
 	}
 	60% {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,10deg);
-				        transform:perspective(400px) rotate3d(0,1,0,10deg);
-				opacity:1;
+			transform:perspective(400px) rotate3d(0,1,0,10deg);
+			opacity:1;
 	}
 	80% {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,-5deg);
-				        transform:perspective(400px) rotate3d(0,1,0,-5deg);
+			transform:perspective(400px) rotate3d(0,1,0,-5deg);
 	}
 	100% {
-				-webkit-transform:perspective(400px);
-				        transform:perspective(400px);
+			transform:perspective(400px);
 	}
 }
 .flipInY {
-	-webkit-animation-name:flipInY;
-	        animation-name:flipInY;
-	-webkit-backface-visibility:visible !important;
-	        backface-visibility:visible !important;
-}
-@-webkit-keyframes flipOutX {
-	from {
-				-webkit-transform:perspective(400px);
-				        transform:perspective(400px);
-	}
-	30% {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,-20deg);
-				        transform:perspective(400px) rotate3d(1,0,0,-20deg);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,90deg);
-				        transform:perspective(400px) rotate3d(1,0,0,90deg);
-				opacity:0;
-	}
+	animation-name:flipInY;
+	backface-visibility:visible !important;
 }
 @keyframes flipOutX {
 	from {
-				-webkit-transform:perspective(400px);
-				        transform:perspective(400px);
+			transform:perspective(400px);
 	}
 	30% {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,-20deg);
-				        transform:perspective(400px) rotate3d(1,0,0,-20deg);
-				opacity:1;
+			transform:perspective(400px) rotate3d(1,0,0,-20deg);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:perspective(400px) rotate3d(1,0,0,90deg);
-				        transform:perspective(400px) rotate3d(1,0,0,90deg);
-				opacity:0;
+			transform:perspective(400px) rotate3d(1,0,0,90deg);
+			opacity:0;
 	}
 }
 .flipOutX {
-	-webkit-animation-name:flipOutX;
-	        animation-name:flipOutX;
-	-webkit-backface-visibility:visible !important;
-	        backface-visibility:visible !important;
-}
-@-webkit-keyframes flipOutY {
-	from {
-				-webkit-transform:perspective(400px);
-				        transform:perspective(400px);
-	}
-	30% {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,-15deg);
-				        transform:perspective(400px) rotate3d(0,1,0,-15deg);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,90deg);
-				        transform:perspective(400px) rotate3d(0,1,0,90deg);
-				opacity:0;
-	}
+	animation-name:flipOutX;
+	backface-visibility:visible !important;
 }
 @keyframes flipOutY {
 	from {
-				-webkit-transform:perspective(400px);
-				        transform:perspective(400px);
+			transform:perspective(400px);
 	}
 	30% {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,-15deg);
-				        transform:perspective(400px) rotate3d(0,1,0,-15deg);
-				opacity:1;
+			transform:perspective(400px) rotate3d(0,1,0,-15deg);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:perspective(400px) rotate3d(0,1,0,90deg);
-				        transform:perspective(400px) rotate3d(0,1,0,90deg);
-				opacity:0;
+			transform:perspective(400px) rotate3d(0,1,0,90deg);
+			opacity:0;
 	}
 }
 .flipOutY {
-	-webkit-animation-name:flipOutY;
-	        animation-name:flipOutY;
-	-webkit-backface-visibility:visible !important;
-	        backface-visibility:visible !important;
-}
-@-webkit-keyframes lightSpeedIn {
-	from {
-				-webkit-transform:translate3d(100%,0,0) skewX(-30deg);
-				        transform:translate3d(100%,0,0) skewX(-30deg);
-				opacity:0;
-	}
-	60% {
-				-webkit-transform:skewX(20deg);
-				        transform:skewX(20deg);
-				opacity:1;
-	}
-	80% {
-				-webkit-transform:skewX(-5deg);
-				        transform:skewX(-5deg);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
-	}
+	animation-name:flipOutY;
+	backface-visibility:visible !important;
 }
 @keyframes lightSpeedIn {
 	from {
-				-webkit-transform:translate3d(100%,0,0) skewX(-30deg);
-				        transform:translate3d(100%,0,0) skewX(-30deg);
-				opacity:0;
+			transform:translate3d(100%,0,0) skewX(-30deg);
+			opacity:0;
 	}
 	60% {
-				-webkit-transform:skewX(20deg);
-				        transform:skewX(20deg);
-				opacity:1;
+			transform:skewX(20deg);
+			opacity:1;
 	}
 	80% {
-				-webkit-transform:skewX(-5deg);
-				        transform:skewX(-5deg);
-				opacity:1;
+			transform:skewX(-5deg);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
+			transform:none;
+			opacity:1;
 	}
 }
 .lightSpeedIn {
-	-webkit-animation-name:lightSpeedIn;
-	        animation-name:lightSpeedIn;
-	-webkit-animation-timing-function:ease-out;
-	        animation-timing-function:ease-out;
-}
-@-webkit-keyframes lightSpeedOut {
-	from {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(100%,0,0) skewX(30deg);
-				        transform:translate3d(100%,0,0) skewX(30deg);
-				opacity:0;
-	}
+	animation-name:lightSpeedIn;
+	animation-timing-function:ease-out;
 }
 @keyframes lightSpeedOut {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(100%,0,0) skewX(30deg);
-				        transform:translate3d(100%,0,0) skewX(30deg);
-				opacity:0;
+			transform:translate3d(100%,0,0) skewX(30deg);
+			opacity:0;
 	}
 }
 .lightSpeedOut {
-	-webkit-animation-name:lightSpeedOut;
-	        animation-name:lightSpeedOut;
-	-webkit-animation-timing-function:ease-in-out;
-	        animation-timing-function:ease-in-out;
-}
-@-webkit-keyframes rotateIn {
-	from {
-				-webkit-transform:rotate3d(0,0,1,-200deg);
-				        transform:rotate3d(0,0,1,-200deg);
-				-webkit-transform-origin:center;
-				        transform-origin:center;
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				-webkit-transform-origin:center;
-				        transform-origin:center;
-				opacity:1;
-	}
+	animation-name:lightSpeedOut;
+	animation-timing-function:ease-in-out;
 }
 @keyframes rotateIn {
 	from {
-				-webkit-transform:rotate3d(0,0,1,-200deg);
-				        transform:rotate3d(0,0,1,-200deg);
-				-webkit-transform-origin:center;
-				        transform-origin:center;
-				opacity:0;
+			transform:rotate3d(0,0,1,-200deg);
+			transform-origin:center;
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				-webkit-transform-origin:center;
-				        transform-origin:center;
-				opacity:1;
+			transform:none;
+			transform-origin:center;
+			opacity:1;
 	}
 }
 .rotateIn {
-	-webkit-animation-name:rotateIn;
-	        animation-name:rotateIn;
-}
-@-webkit-keyframes rotateInDownLeft {
-	from {
-				-webkit-transform:rotate3d(0,0,1,-45deg);
-				        transform:rotate3d(0,0,1,-45deg);
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:1;
-	}
+	animation-name:rotateIn;
 }
 @keyframes rotateInDownLeft {
 	from {
-				-webkit-transform:rotate3d(0,0,1,-45deg);
-				        transform:rotate3d(0,0,1,-45deg);
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:0;
+			transform:rotate3d(0,0,1,-45deg);
+			transform-origin:left bottom;
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:1;
+			transform:none;
+			transform-origin:left bottom;
+			opacity:1;
 	}
 }
 .rotateInDownLeft {
-	-webkit-animation-name:rotateInDownLeft;
-	        animation-name:rotateInDownLeft;
-}
-@-webkit-keyframes rotateInDownRight {
-	from {
-				-webkit-transform:rotate3d(0,0,1,45deg);
-				        transform:rotate3d(0,0,1,45deg);
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:1;
-	}
+	animation-name:rotateInDownLeft;
 }
 @keyframes rotateInDownRight {
 	from {
-				-webkit-transform:rotate3d(0,0,1,45deg);
-				        transform:rotate3d(0,0,1,45deg);
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:0;
+			transform:rotate3d(0,0,1,45deg);
+			transform-origin:right bottom;
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:1;
+			transform:none;
+			transform-origin:right bottom;
+			opacity:1;
 	}
 }
 .rotateInDownRight {
-	-webkit-animation-name:rotateInDownRight;
-	        animation-name:rotateInDownRight;
-}
-@-webkit-keyframes rotateInUpLeft {
-	from {
-				-webkit-transform:rotate3d(0,0,1,45deg);
-				        transform:rotate3d(0,0,1,45deg);
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:1;
-	}
+	animation-name:rotateInDownRight;
 }
 @keyframes rotateInUpLeft {
 	from {
-				-webkit-transform:rotate3d(0,0,1,45deg);
-				        transform:rotate3d(0,0,1,45deg);
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:0;
+			transform:rotate3d(0,0,1,45deg);
+			transform-origin:left bottom;
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:1;
+			transform:none;
+			transform-origin:left bottom;
+			opacity:1;
 	}
 }
 .rotateInUpLeft {
-	-webkit-animation-name:rotateInUpLeft;
-	        animation-name:rotateInUpLeft;
-}
-@-webkit-keyframes rotateInUpRight {
-	from {
-				-webkit-transform:rotate3d(0,0,1,-90deg);
-				        transform:rotate3d(0,0,1,-90deg);
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:1;
-	}
+	animation-name:rotateInUpLeft;
 }
 @keyframes rotateInUpRight {
 	from {
-				-webkit-transform:rotate3d(0,0,1,-90deg);
-				        transform:rotate3d(0,0,1,-90deg);
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:0;
+			transform:rotate3d(0,0,1,-90deg);
+			transform-origin:right bottom;
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:1;
+			transform:none;
+			transform-origin:right bottom;
+			opacity:1;
 	}
 }
 .rotateInUpRight {
-	-webkit-animation-name:rotateInUpRight;
-	        animation-name:rotateInUpRight;
-}
-@-webkit-keyframes rotateOut {
-	from {
-				-webkit-transform-origin:center;
-				        transform-origin:center;
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:rotate3d(0,0,1,200deg);
-				        transform:rotate3d(0,0,1,200deg);
-				-webkit-transform-origin:center;
-				        transform-origin:center;
-				opacity:0;
-	}
+	animation-name:rotateInUpRight;
 }
 @keyframes rotateOut {
 	from {
-				-webkit-transform-origin:center;
-				        transform-origin:center;
-				opacity:1;
+			transform-origin:center;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:rotate3d(0,0,1,200deg);
-				        transform:rotate3d(0,0,1,200deg);
-				-webkit-transform-origin:center;
-				        transform-origin:center;
-				opacity:0;
+			transform:rotate3d(0,0,1,200deg);
+			transform-origin:center;
+			opacity:0;
 	}
 }
 .rotateOut {
-	-webkit-animation-name:rotateOut;
-	        animation-name:rotateOut;
-}
-@-webkit-keyframes rotateOutDownLeft {
-	from {
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:rotate3d(0,0,1,45deg);
-				        transform:rotate3d(0,0,1,45deg);
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:0;
-	}
+	animation-name:rotateOut;
 }
 @keyframes rotateOutDownLeft {
 	from {
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:1;
+			transform-origin:left bottom;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:rotate3d(0,0,1,45deg);
-				        transform:rotate3d(0,0,1,45deg);
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:0;
+			transform:rotate3d(0,0,1,45deg);
+			transform-origin:left bottom;
+			opacity:0;
 	}
 }
 .rotateOutDownLeft {
-	-webkit-animation-name:rotateOutDownLeft;
-	        animation-name:rotateOutDownLeft;
-}
-@-webkit-keyframes rotateOutDownRight {
-	from {
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:rotate3d(0,0,1,-45deg);
-				        transform:rotate3d(0,0,1,-45deg);
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:0;
-	}
+	animation-name:rotateOutDownLeft;
 }
 @keyframes rotateOutDownRight {
 	from {
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:1;
+			transform-origin:right bottom;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:rotate3d(0,0,1,-45deg);
-				        transform:rotate3d(0,0,1,-45deg);
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:0;
+			transform:rotate3d(0,0,1,-45deg);
+			transform-origin:right bottom;
+			opacity:0;
 	}
 }
 .rotateOutDownRight {
-	-webkit-animation-name:rotateOutDownRight;
-	        animation-name:rotateOutDownRight;
-}
-@-webkit-keyframes rotateOutUpLeft {
-	from {
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:rotate3d(0,0,1,-45deg);
-				        transform:rotate3d(0,0,1,-45deg);
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:0;
-	}
+	animation-name:rotateOutDownRight;
 }
 @keyframes rotateOutUpLeft {
 	from {
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:1;
+			transform-origin:left bottom;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:rotate3d(0,0,1,-45deg);
-				        transform:rotate3d(0,0,1,-45deg);
-				-webkit-transform-origin:left bottom;
-				        transform-origin:left bottom;
-				opacity:0;
+			transform:rotate3d(0,0,1,-45deg);
+			transform-origin:left bottom;
+			opacity:0;
 	}
 }
 .rotateOutUpLeft {
-	-webkit-animation-name:rotateOutUpLeft;
-	        animation-name:rotateOutUpLeft;
-}
-@-webkit-keyframes rotateOutUpRight {
-	from {
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:rotate3d(0,0,1,90deg);
-				        transform:rotate3d(0,0,1,90deg);
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:0;
-	}
+	animation-name:rotateOutUpLeft;
 }
 @keyframes rotateOutUpRight {
 	from {
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:1;
+			transform-origin:right bottom;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:rotate3d(0,0,1,90deg);
-				        transform:rotate3d(0,0,1,90deg);
-				-webkit-transform-origin:right bottom;
-				        transform-origin:right bottom;
-				opacity:0;
+			transform:rotate3d(0,0,1,90deg);
+			transform-origin:right bottom;
+			opacity:0;
 	}
 }
 .rotateOutUpRight {
-	-webkit-animation-name:rotateOutUpRight;
-	        animation-name:rotateOutUpRight;
-}
-@-webkit-keyframes hinge {
-	0% {
-				-webkit-transform-origin:top left;
-				        transform-origin:top left;
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-	20%,60% {
-				-webkit-transform:rotate3d(0,0,1,80deg);
-				        transform:rotate3d(0,0,1,80deg);
-				-webkit-transform-origin:top left;
-				        transform-origin:top left;
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-	40%,80% {
-				-webkit-transform:rotate3d(0,0,1,60deg);
-				        transform:rotate3d(0,0,1,60deg);
-				-webkit-transform-origin:top left;
-				        transform-origin:top left;
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(0,700px,0);
-				        transform:translate3d(0,700px,0);
-				opacity:0;
-	}
+	animation-name:rotateOutUpRight;
 }
 @keyframes hinge {
 	0% {
-				-webkit-transform-origin:top left;
-				        transform-origin:top left;
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform-origin:top left;
+			animation-timing-function:ease-in-out;
 	}
 	20%,60% {
-				-webkit-transform:rotate3d(0,0,1,80deg);
-				        transform:rotate3d(0,0,1,80deg);
-				-webkit-transform-origin:top left;
-				        transform-origin:top left;
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:rotate3d(0,0,1,80deg);
+			transform-origin:top left;
+			animation-timing-function:ease-in-out;
 	}
 	40%,80% {
-				-webkit-transform:rotate3d(0,0,1,60deg);
-				        transform:rotate3d(0,0,1,60deg);
-				-webkit-transform-origin:top left;
-				        transform-origin:top left;
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-				opacity:1;
+			transform:rotate3d(0,0,1,60deg);
+			transform-origin:top left;
+			animation-timing-function:ease-in-out;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(0,700px,0);
-				        transform:translate3d(0,700px,0);
-				opacity:0;
+			transform:translate3d(0,700px,0);
+			opacity:0;
 	}
 }
 .hinge {
-	-webkit-animation-name: hinge;
-	        animation-name: hinge;
+	animation-name: hinge;
 }
 /* originally authored by Nick Pettit - https://github.com/nickpettit/glide */
-@-webkit-keyframes rollIn {
-	from {
-				-webkit-transform:translate3d(-100%,0,0) rotate3d(0,0,1,-120deg);
-				        transform:translate3d(-100%,0,0) rotate3d(0,0,1,-120deg);
-				opacity:0;
-	}
-	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
-	}
-}
 @keyframes rollIn {
 	from {
-				-webkit-transform:translate3d(-100%,0,0) rotate3d(0,0,1,-120deg);
-				        transform:translate3d(-100%,0,0) rotate3d(0,0,1,-120deg);
-				opacity:0;
+			transform:translate3d(-100%,0,0) rotate3d(0,0,1,-120deg);
+			opacity:0;
 	}
 	100% {
-				-webkit-transform:none;
-				        transform:none;
-				opacity:1;
+			transform:none;
+			opacity:1;
 	}
 }
 .rollIn {
-	-webkit-animation-name: rollIn;
-	        animation-name: rollIn;
+	animation-name: rollIn;
 }
 /* originally authored by Nick Pettit - https://github.com/nickpettit/glide */
-@-webkit-keyframes rollOut {
-	from {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:translate3d(100%,0,0) rotate3d(0,0,1,120deg);
-				        transform:translate3d(100%,0,0) rotate3d(0,0,1,120deg);
-				opacity:0;
-	}
-}
 @keyframes rollOut {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:translate3d(100%,0,0) rotate3d(0,0,1,120deg);
-				        transform:translate3d(100%,0,0) rotate3d(0,0,1,120deg);
-				opacity:0;
+			transform:translate3d(100%,0,0) rotate3d(0,0,1,120deg);
+			opacity:0;
 	}
 }
 .rollOut {
-	-webkit-animation-name:rollOut;
-	        animation-name:rollOut;
-}
-@-webkit-keyframes zoomIn {
-	from {
-				-webkit-transform:scale3d(.3,.3,.3);
-				        transform:scale3d(.3,.3,.3);
-				opacity:0;
-	}
-	50% {
-				opacity:1;
-	}
+	animation-name:rollOut;
 }
 @keyframes zoomIn {
 	from {
-				-webkit-transform:scale3d(.3,.3,.3);
-				        transform:scale3d(.3,.3,.3);
-				opacity:0;
+			transform:scale3d(.3,.3,.3);
+			opacity:0;
 	}
 	50% {
-				opacity:1;
+			opacity:1;
 	}
 }
 .zoomIn {
-	-webkit-animation-name:zoomIn;
-	        animation-name:zoomIn;
-}
-@-webkit-keyframes zoomInDown {
-	from {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(0,-1000px,0);
-				        transform:scale3d(.1,.1,.1) translate3d(0,-1000px,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:0;
-	}
-	60% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(0,60px,0);
-				        transform:scale3d(.475,.475,.475) translate3d(0,60px,0);
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:1;
-	}
+	animation-name:zoomIn;
 }
 @keyframes zoomInDown {
 	from {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(0,-1000px,0);
-				        transform:scale3d(.1,.1,.1) translate3d(0,-1000px,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:0;
+			transform:scale3d(.1,.1,.1) translate3d(0,-1000px,0);
+			animation-timing-function:cubic-bezier(.550,.055,.675,.190);
+			opacity:0;
 	}
 	60% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(0,60px,0);
-				        transform:scale3d(.475,.475,.475) translate3d(0,60px,0);
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:1;
+			transform:scale3d(.475,.475,.475) translate3d(0,60px,0);
+			animation-timing-function:cubic-bezier(.175,.885,.320,1);
+			opacity:1;
 	}
 }
 .zoomInDown {
-	-webkit-animation-name:zoomInDown;
-	        animation-name:zoomInDown;
-}
-@-webkit-keyframes zoomInLeft {
-	from {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(-1000px,0,0);
-				        transform:scale3d(.1,.1,.1) translate3d(-1000px,0,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:0;
-	}
-	60% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(10px,0,0);
-				        transform:scale3d(.475,.475,.475) translate3d(10px,0,0);
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:1;
-	}
+	animation-name:zoomInDown;
 }
 @keyframes zoomInLeft {
 	from {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(-1000px,0,0);
-				        transform:scale3d(.1,.1,.1) translate3d(-1000px,0,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:0;
+			transform:scale3d(.1,.1,.1) translate3d(-1000px,0,0);
+			animation-timing-function:cubic-bezier(.550,.055,.675,.190);
+			opacity:0;
 	}
 	60% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(10px,0,0);
-				        transform:scale3d(.475,.475,.475) translate3d(10px,0,0);
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:1;
+			transform:scale3d(.475,.475,.475) translate3d(10px,0,0);
+			animation-timing-function:cubic-bezier(.175,.885,.320,1);
+			opacity:1;
 	}
 }
 .zoomInLeft {
-	-webkit-animation-name:zoomInLeft;
-	        animation-name:zoomInLeft;
-}
-@-webkit-keyframes zoomInRight {
-	from {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(1000px,0,0);
-				        transform:scale3d(.1,.1,.1) translate3d(1000px,0,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:0;
-	}
-	60% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(-10px,0,0);
-				        transform:scale3d(.475,.475,.475) translate3d(-10px,0,0);
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:1;
-	}
+	animation-name:zoomInLeft;
 }
 @keyframes zoomInRight {
 	from {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(1000px,0,0);
-				        transform:scale3d(.1,.1,.1) translate3d(1000px,0,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:0;
+			transform:scale3d(.1,.1,.1) translate3d(1000px,0,0);
+			animation-timing-function:cubic-bezier(.550,.055,.675,.190);
+			opacity:0;
 	}
 	60% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(-10px,0,0);
-				        transform:scale3d(.475,.475,.475) translate3d(-10px,0,0);
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:1;
+			transform:scale3d(.475,.475,.475) translate3d(-10px,0,0);
+			animation-timing-function:cubic-bezier(.175,.885,.320,1);
+			opacity:1;
 	}
 }
 .zoomInRight {
-	-webkit-animation-name:zoomInRight;
-	        animation-name:zoomInRight;
-}
-@-webkit-keyframes zoomInUp {
-	from {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(0,1000px,0);
-				        transform:scale3d(.1,.1,.1) translate3d(0,1000px,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:0;
-	}
-	60% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(0,-60px,0);
-				        transform:scale3d(.475,.475,.475) translate3d(0,-60px,0);
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:1;
-	}
+	animation-name:zoomInRight;
 }
 @keyframes zoomInUp {
 	from {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(0,1000px,0);
-				        transform:scale3d(.1,.1,.1) translate3d(0,1000px,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:0;
+			transform:scale3d(.1,.1,.1) translate3d(0,1000px,0);
+			animation-timing-function:cubic-bezier(.550,.055,.675,.190);
+			opacity:0;
 	}
 	60% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(0,-60px,0);
-				        transform:scale3d(.475,.475,.475) translate3d(0,-60px,0);
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:1;
+			transform:scale3d(.475,.475,.475) translate3d(0,-60px,0);
+			animation-timing-function:cubic-bezier(.175,.885,.320,1);
+			opacity:1;
 	}
 }
 .zoomInUp {
-	-webkit-animation-name:zoomInUp;
-	        animation-name:zoomInUp;
-}
-@-webkit-keyframes zoomOut {
-	from {
-				opacity:1;
-	}
-	50% {
-				-webkit-transform:scale3d(.3,.3,.3);
-				        transform:scale3d(.3,.3,.3);
-				opacity:0;
-	}
-	100% {
-				opacity:0;
-	}
+	animation-name:zoomInUp;
 }
 @keyframes zoomOut {
 	from {
-				opacity:1;
+			opacity:1;
 	}
 	50% {
-				-webkit-transform:scale3d(.3,.3,.3);
-				        transform:scale3d(.3,.3,.3);
-				opacity:0;
+			transform:scale3d(.3,.3,.3);
+			opacity:0;
 	}
 	100% {
-				opacity:0;
+			opacity:0;
 	}
 }
 .zoomOut {
-	-webkit-animation-name:zoomOut;
-	        animation-name:zoomOut;
-}
-@-webkit-keyframes zoomOutDown {
-	40% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(0,-60px,0);
-				        transform:scale3d(.475,.475,.475) translate3d(0,-60px,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(0,2000px,0);
-				        transform:scale3d(.1,.1,.1) translate3d(0,2000px,0);
-				-webkit-transform-origin:center bottom;
-				        transform-origin:center bottom;
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:0;
-	}
+	animation-name:zoomOut;
 }
 @keyframes zoomOutDown {
 	40% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(0,-60px,0);
-				        transform:scale3d(.475,.475,.475) translate3d(0,-60px,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:1;
+			transform:scale3d(.475,.475,.475) translate3d(0,-60px,0);
+			animation-timing-function:cubic-bezier(.550,.055,.675,.190);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(0,2000px,0);
-				        transform:scale3d(.1,.1,.1) translate3d(0,2000px,0);
-				-webkit-transform-origin:center bottom;
-				        transform-origin:center bottom;
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:0;
+			transform:scale3d(.1,.1,.1) translate3d(0,2000px,0);
+			transform-origin:center bottom;
+			animation-timing-function:cubic-bezier(.175,.885,.320,1);
+			opacity:0;
 	}
 }
 .zoomOutDown {
-	-webkit-animation-name:zoomOutDown;
-	        animation-name:zoomOutDown;
-}
-@-webkit-keyframes zoomOutLeft {
-	40% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(42px,0,0);
-				        transform:scale3d(.475,.475,.475) translate3d(42px,0,0);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:scale(.1) translate3d(-2000px,0,0);
-				        transform:scale(.1) translate3d(-2000px,0,0);
-				-webkit-transform-origin:left center;
-				        transform-origin:left center;
-				opacity:0;
-	}
+	animation-name:zoomOutDown;
 }
 @keyframes zoomOutLeft {
 	40% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(42px,0,0);
-				        transform:scale3d(.475,.475,.475) translate3d(42px,0,0);
-				opacity:1;
+			transform:scale3d(.475,.475,.475) translate3d(42px,0,0);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:scale(.1) translate3d(-2000px,0,0);
-				        transform:scale(.1) translate3d(-2000px,0,0);
-				-webkit-transform-origin:left center;
-				        transform-origin:left center;
-				opacity:0;
+			transform:scale(.1) translate3d(-2000px,0,0);
+			transform-origin:left center;
+			opacity:0;
 	}
 }
 .zoomOutLeft {
-	-webkit-animation-name:zoomOutLeft;
-	        animation-name:zoomOutLeft;
-}
-@-webkit-keyframes zoomOutRight {
-	40% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(-42px,0,0);
-				        transform:scale3d(.475,.475,.475) translate3d(-42px,0,0);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:scale(.1) translate3d(2000px,0,0);
-				        transform:scale(.1) translate3d(2000px,0,0);
-				-webkit-transform-origin:right center;
-				        transform-origin:right center;
-				opacity:0;
-	}
+	animation-name:zoomOutLeft;
 }
 @keyframes zoomOutRight {
 	40% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(-42px,0,0);
-				        transform:scale3d(.475,.475,.475) translate3d(-42px,0,0);
-				opacity:1;
+			transform:scale3d(.475,.475,.475) translate3d(-42px,0,0);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:scale(.1) translate3d(2000px,0,0);
-				        transform:scale(.1) translate3d(2000px,0,0);
-				-webkit-transform-origin:right center;
-				        transform-origin:right center;
-				opacity:0;
+			transform:scale(.1) translate3d(2000px,0,0);
+			transform-origin:right center;
+			opacity:0;
 	}
 }
 .zoomOutRight {
-	-webkit-animation-name:zoomOutRight;
-	        animation-name:zoomOutRight;
-}
-@-webkit-keyframes zoomOutUp {
-	40% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(0,60px,0);
-				        transform:scale3d(.475,.475,.475) translate3d(0,60px,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(0,-2000px,0);
-				        transform:scale3d(.1,.1,.1) translate3d(0,-2000px,0);
-				-webkit-transform-origin:center bottom;
-				        transform-origin:center bottom;
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:0;
-	}
+	animation-name:zoomOutRight;
 }
 @keyframes zoomOutUp {
 	40% {
-				-webkit-transform:scale3d(.475,.475,.475) translate3d(0,60px,0);
-				        transform:scale3d(.475,.475,.475) translate3d(0,60px,0);
-				-webkit-animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				        animation-timing-function:cubic-bezier(.550,.055,.675,.190);
-				opacity:1;
+			transform:scale3d(.475,.475,.475) translate3d(0,60px,0);
+			animation-timing-function:cubic-bezier(.550,.055,.675,.190);
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:scale3d(.1,.1,.1) translate3d(0,-2000px,0);
-				        transform:scale3d(.1,.1,.1) translate3d(0,-2000px,0);
-				-webkit-transform-origin:center bottom;
-				        transform-origin:center bottom;
-				-webkit-animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				        animation-timing-function:cubic-bezier(.175,.885,.320,1);
-				opacity:0;
+			transform:scale3d(.1,.1,.1) translate3d(0,-2000px,0);
+			transform-origin:center bottom;
+			animation-timing-function:cubic-bezier(.175,.885,.320,1);
+			opacity:0;
 	}
 }
 .zoomOutUp {
-	-webkit-animation-name:zoomOutUp;
-	        animation-name:zoomOutUp;
-}
-@-webkit-keyframes slideInDown {
-	from {
-				visibility:visible;
-				-webkit-transform:translate3d(0,-100%,0);
-				        transform:translate3d(0,-100%,0);
-	}
-	100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-	}
+	animation-name:zoomOutUp;
 }
 @keyframes slideInDown {
 	from {
-				visibility:visible;
-				-webkit-transform:translate3d(0,-100%,0);
-				        transform:translate3d(0,-100%,0);
+			visibility:visible;
+			transform:translate3d(0,-100%,0);
 	}
 	100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
+			transform:translate3d(0,0,0);
 	}
 }
 .slideInDown {
-	-webkit-animation-name:slideInDown;
-	        animation-name:slideInDown;
-}
-@-webkit-keyframes slideInLeft {
-	from {
-				visibility:visible;
-				-webkit-transform:translate3d(-100%,0,0);
-				        transform:translate3d(-100%,0,0);
-	}
-	100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-	}
+	animation-name:slideInDown;
 }
 @keyframes slideInLeft {
 	from {
-				visibility:visible;
-				-webkit-transform:translate3d(-100%,0,0);
-				        transform:translate3d(-100%,0,0);
+			visibility:visible;
+			transform:translate3d(-100%,0,0);
 	}
 	100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
+			transform:translate3d(0,0,0);
 	}
 }
 .slideInLeft {
-	-webkit-animation-name:slideInLeft;
-	        animation-name:slideInLeft;
-}
-@-webkit-keyframes slideInRight {
-	from {
-				visibility:visible;
-				-webkit-transform:translate3d(100%,0,0);
-				        transform:translate3d(100%,0,0);
-	}
-	100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-	}
+	animation-name:slideInLeft;
 }
 @keyframes slideInRight {
 	from {
-				visibility:visible;
-				-webkit-transform:translate3d(100%,0,0);
-				        transform:translate3d(100%,0,0);
+			visibility:visible;
+			transform:translate3d(100%,0,0);
 	}
 	100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
+			transform:translate3d(0,0,0);
 	}
 }
 .slideInRight {
-	-webkit-animation-name:slideInRight;
-	        animation-name:slideInRight;
-}
-@-webkit-keyframes slideInUp {
-	from {
-				visibility:visible;
-				-webkit-transform:translate3d(0,100%,0);
-				        transform:translate3d(0,100%,0);
-	}
-	100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-	}
+	animation-name:slideInRight;
 }
 @keyframes slideInUp {
 	from {
-				visibility:visible;
-				-webkit-transform:translate3d(0,100%,0);
-				        transform:translate3d(0,100%,0);
+			visibility:visible;
+			transform:translate3d(0,100%,0);
 	}
 	100% {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
+			transform:translate3d(0,0,0);
 	}
 }
 .slideInUp {
-	-webkit-animation-name:slideInUp;
-	        animation-name:slideInUp;
-}
-@-webkit-keyframes slideOutDown {
-	from {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-	}
-	100% {
-				visibility:hidden;
-				-webkit-transform:translate3d(0,100%,0);
-				        transform:translate3d(0,100%,0);
-	}
+	animation-name:slideInUp;
 }
 @keyframes slideOutDown {
 	from {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
+			transform:translate3d(0,0,0);
 	}
 	100% {
-				visibility:hidden;
-				-webkit-transform:translate3d(0,100%,0);
-				        transform:translate3d(0,100%,0);
+			visibility:hidden;
+			transform:translate3d(0,100%,0);
 	}
 }
 .slideOutDown {
-	-webkit-animation-name:slideOutDown;
-	        animation-name:slideOutDown;
-}
-@-webkit-keyframes slideOutLeft {
-	from {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-	}
-	100% {
-				visibility:hidden;
-				-webkit-transform:translate3d(-100%,0,0);
-				        transform:translate3d(-100%,0,0);
-	}
+	animation-name:slideOutDown;
 }
 @keyframes slideOutLeft {
 	from {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
+			transform:translate3d(0,0,0);
 	}
 	100% {
-				visibility:hidden;
-				-webkit-transform:translate3d(-100%,0,0);
-				        transform:translate3d(-100%,0,0);
+			visibility:hidden;
+			transform:translate3d(-100%,0,0);
 	}
 }
 .slideOutLeft {
-	-webkit-animation-name:slideOutLeft;
-	        animation-name:slideOutLeft;
-}
-@-webkit-keyframes slideOutRight {
-	from {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-	}
-	100% {
-				visibility:hidden;
-				-webkit-transform:translate3d(100%,0,0);
-				        transform:translate3d(100%,0,0);
-	}
+	animation-name:slideOutLeft;
 }
 @keyframes slideOutRight {
 	from {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
+			transform:translate3d(0,0,0);
 	}
 	100% {
-				visibility:hidden;
-				-webkit-transform:translate3d(100%,0,0);
-				        transform:translate3d(100%,0,0);
+			visibility:hidden;
+			transform:translate3d(100%,0,0);
 	}
 }
 .slideOutRight {
-	-webkit-animation-name:slideOutRight;
-	        animation-name:slideOutRight;
-}
-@-webkit-keyframes slideOutUp {
-	from {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
-	}
-	100% {
-				visibility:hidden;
-				-webkit-transform:translate3d(0,-100%,0);
-				        transform:translate3d(0,-100%,0);
-	}
+	animation-name:slideOutRight;
 }
 @keyframes slideOutUp {
 	from {
-				-webkit-transform:translate3d(0,0,0);
-				        transform:translate3d(0,0,0);
+			transform:translate3d(0,0,0);
 	}
 	100% {
-				visibility:hidden;
-				-webkit-transform:translate3d(0,-100%,0);
-				        transform:translate3d(0,-100%,0);
+			visibility:hidden;
+			transform:translate3d(0,-100%,0);
 	}
 }
 .slideOutUp {
-	-webkit-animation-name: slideOutUp;
-	        animation-name: slideOutUp;
+	animation-name: slideOutUp;
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes pulsate {
-	0% {
-				-webkit-transform:scale(.01,.01);
-				        transform:scale(.01,.01);
-				opacity:0;
-	}
-	50% {
-				opacity:1;
-	}
-	100% {
-				-webkit-transform:scale(2.0,2.0);
-				        transform:scale(2.0,2.0);
-				opacity: 0;
-	}
-}
 @keyframes pulsate {
 	0% {
-				-webkit-transform:scale(.01,.01);
-				        transform:scale(.01,.01);
-				opacity:0;
+			transform:scale(.01,.01);
+			opacity:0;
 	}
 	50% {
-				opacity:1;
+			opacity:1;
 	}
 	100% {
-				-webkit-transform:scale(2.0,2.0);
-				        transform:scale(2.0,2.0);
-				opacity: 0;
+			transform:scale(2.0,2.0);
+			opacity: 0;
 	}
 }
 /*----------------------------------------------------------------------------*/
-@-webkit-keyframes bobbing {
-	0% {
-				-webkit-transform:translate(0px,0px);
-				        transform:translate(0px,0px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-	50% {
-				-webkit-transform:translate(0px,8px);
-				        transform:translate(0px,8px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-	100% {
-				-webkit-transform:translate(0px,0px);
-				        transform:translate(0px,0px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-}
 @keyframes bobbing {
 	0% {
-				-webkit-transform:translate(0px,0px);
-				        transform:translate(0px,0px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:translate(0px,0px);
+			animation-timing-function:ease-in-out;
 	}
 	50% {
-				-webkit-transform:translate(0px,8px);
-				        transform:translate(0px,8px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:translate(0px,8px);
+			animation-timing-function:ease-in-out;
 	}
 	100% {
-				-webkit-transform:translate(0px,0px);
-				        transform:translate(0px,0px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-}
-@-webkit-keyframes drifting-left {
-	0% {
-				-webkit-transform:translate(0px,0px);
-				        transform:translate(0px,0px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-	50% {
-				-webkit-transform:translate(8px,0px);
-				        transform:translate(8px,0px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-	100% {
-				-webkit-transform:translate(0px,0px);
-				        transform:translate(0px,0px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:translate(0px,0px);
+			animation-timing-function: ease-in-out;
 	}
 }
 @keyframes drifting-left {
 	0% {
-				-webkit-transform:translate(0px,0px);
-				        transform:translate(0px,0px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:translate(0px,0px);
+			animation-timing-function:ease-in-out;
 	}
 	50% {
-				-webkit-transform:translate(8px,0px);
-				        transform:translate(8px,0px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
+			transform:translate(8px,0px);
+			animation-timing-function:ease-in-out;
 	}
 	100% {
-				-webkit-transform:translate(0px,0px);
-				        transform:translate(0px,0px);
-				-webkit-animation-timing-function:ease-in-out;
-				        animation-timing-function:ease-in-out;
-	}
-}
-@-webkit-keyframes drifting-right {
-	0% {
-			 -webkit-transform:translate(8px,0px);
-			         transform:translate(8px,0px);
-			 -webkit-animation-timing-function:ease-in-out;
-			         animation-timing-function:ease-in-out;
-	}
-	50% {
-			 -webkit-transform:translate(0px,0px);
-			         transform:translate(0px,0px);
-			 -webkit-animation-timing-function:ease-in-out;
-			         animation-timing-function:ease-in-out;
-	}
-	100% {
-			 -webkit-transform:translate(8px,0px);
-			         transform:translate(8px,0px);
-			 -webkit-animation-timing-function: ease-in-out;
-			         animation-timing-function: ease-in-out;
+			transform:translate(0px,0px);
+			animation-timing-function: ease-in-out;
 	}
 }
 @keyframes drifting-right {
 	0% {
-			 -webkit-transform:translate(8px,0px);
-			         transform:translate(8px,0px);
-			 -webkit-animation-timing-function:ease-in-out;
-			         animation-timing-function:ease-in-out;
+		        transform:translate(8px,0px);
+		        animation-timing-function:ease-in-out;
 	}
 	50% {
-			 -webkit-transform:translate(0px,0px);
-			         transform:translate(0px,0px);
-			 -webkit-animation-timing-function:ease-in-out;
-			         animation-timing-function:ease-in-out;
+		        transform:translate(0px,0px);
+		        animation-timing-function: ease-in-out;
 	}
 	100% {
-			 -webkit-transform:translate(8px,0px);
-			         transform:translate(8px,0px);
-			 -webkit-animation-timing-function: ease-in-out;
-			         animation-timing-function: ease-in-out;
+		        transform:translate(8px,0px);
+		        animation-timing-function:ease-in-out;
 	}
 }

--- a/public_html/lib/css/darkmode.css
+++ b/public_html/lib/css/darkmode.css
@@ -1,8 +1,8 @@
 @charset "utf-8";
 @media screen and (max-width:800px) {
 	.dm-menu-ico-logo {
-			background:url(/img/icons/menu/logo-wide-dark.png) center center/36px no-repeat!important;
-			background-size:contain!important
+		background:url(/img/icons/menu/logo-wide-dark.png) center center/36px no-repeat!important;
+		background-size:contain!important
 	}
 }
 .dm-gradient {
@@ -13,16 +13,13 @@
 	background:#111525!important
 }
 .dm-divider {
-	background:-webkit-gradient(linear,right top, left top,from(rgba(255,255,255,0)),to(rgb(255 255 255/20%)))!important;
-	background:-o-linear-gradient(right,rgba(255,255,255,0),rgb(255 255 255/20%))!important;
 	background:linear-gradient(to left,rgba(255,255,255,0),rgb(255 255 255/20%))!important
 }
 .dm-bg-2 {
 	background:#191f36!important
 }
 .dm-invert {
-	-webkit-filter:invert(100%)!important;
-	        filter:invert(100%)!important
+	filter:invert(100%)!important
 }
 .dm-default {
 	background:#111525!important
@@ -41,7 +38,6 @@
 	color:#fff!important
 }
 .dm-header {
-	background:-o-linear-gradient(225deg,rgba(0,18,59,.7) 25%,rgba(105,0,243,.7) 100%)!important;
 	background:linear-gradient(-135deg,rgba(0,18,59,.7) 25%,rgba(105,0,243,.7) 100%)!important
 }
 .dm-discord {

--- a/public_html/lib/css/debug.css
+++ b/public_html/lib/css/debug.css
@@ -9,8 +9,7 @@
 	border:1px solid rgba(255,255,255,0.1);
 	border-radius:12px;
 	height:600px;
-	-webkit-box-shadow:rgba(0,0,0,0.1) 0px 10px 32px 0px;
-	        box-shadow:rgba(0,0,0,0.1) 0px 10px 32px 0px;
+	box-shadow:rgba(0,0,0,0.1) 0px 10px 32px 0px;
 	position:relative;
 	cursor:default;
 	margin-bottom:40px;

--- a/public_html/lib/css/debug.css
+++ b/public_html/lib/css/debug.css
@@ -351,7 +351,7 @@
 	        animation-iteration-count:1;
 	color:#fff;
 	text-shadow: rgba(0,0,0,.25) 0 2px 2px;
-	display:none1;
+	display:none;
 }
 .reddit-menu-tx2-block {
 	margin-bottom:20px;

--- a/public_html/lib/css/main.css
+++ b/public_html/lib/css/main.css
@@ -56,12 +56,6 @@ a:hover {
     text-decoration: none;
     color: #39f
 }
-
-::-moz-selection {
-    background: #39f;
-    color: #fff
-}
-
 ::selection {
     background: #39f;
     color: #fff
@@ -78,23 +72,6 @@ a:hover {
 ::-webkit-scrollbar-thumb {
     background: #a9a9a9
 }
-
-::-webkit-input-placeholder {
-    color: #0074e7
-}
-
-::-moz-placeholder {
-    color: #0074e7
-}
-
-:-ms-input-placeholder {
-    color: #0074e7
-}
-
-::-ms-input-placeholder {
-    color: #0074e7
-}
-
 ::placeholder {
     color: #0074e7
 }
@@ -146,31 +123,26 @@ a:hover {
 }
 
 .wavebar-con-wrap {
-    width: 100%;
-    position: absolute;
-    bottom: 0;
-    -webkit-transition: all 1s ease-in-out 0s;
-    -o-transition: all 1s ease-in-out 0s;
-    transition: all 1s ease-in-out 0s
+	width:100%;
+	position:absolute;
+	bottom:0;
+	transition:all 1s ease-in-out 0s
 }
 
 .wavebar-svg-object {
-    background: url(/img/graphics/svg/wavebar.svg) repeat-x;
-    position: absolute;
-    top: -198px;
-    width: 6144px;
-    height: 198px;
-    -webkit-animation: 11s cubic-bezier(.36,.45,.63,.53) 0s infinite normal none running wavebar-svg-object;
-    animation: 11s cubic-bezier(.36,.45,.63,.53) 0s infinite normal none running wavebar-svg-object;
-    -webkit-transform: translate3d(0px,0px,0px);
-    transform: translate3d(0px,0px,0px)
+	background:url(/img/graphics/svg/wavebar.svg) repeat-x;
+	position:absolute;
+	top:-198px;
+	width:6144px;
+	height:198px;
+	animation:11s cubic-bezier(.36,.45,.63,.53) 0s infinite normal none running wavebar-svg-object;
+	transform:translate3d(0px,0px,0px)
 }
 
 .wavebar-svg-object:nth-of-type(2) {
-    top: -174px;
-    -webkit-animation: 11s cubic-bezier(.4,.2,.2,.2) -.124s infinite normal none running wavebar-svg-object,11s ease -1.24s infinite normal none running swell;
-    animation: 11s cubic-bezier(.4,.2,.2,.2) -.124s infinite normal none running wavebar-svg-object,11s ease -1.24s infinite normal none running swell;
-    opacity: 1
+	top:-174px;
+	animation:11s cubic-bezier(.4,.2,.2,.2) -.124s infinite normal none running wavebar-svg-object,11s ease -1.24s infinite normal none running swell;
+	opacity:1
 }
 
 .mini-menu-con-dimmer {
@@ -184,67 +156,50 @@ a:hover {
 }
 
 .mini-menu-con-container {
-    position: fixed;
-    height: auto;
-    width: 356px;
-    background: -webkit-gradient(linear,left bottom,left top,color-stop(10%,rgb(82 86 179/10%)),to(rgb(82 86 179/80%)));
-    background: -o-linear-gradient(bottom,rgb(82 86 179/10%) 10%,rgb(82 86 179/80%) 100%);
-    background: linear-gradient(0deg,rgb(82 86 179/10%) 10%,rgb(82 86 179/80%) 100%);
-    -webkit-box-shadow: inset 0 0 0 1px rgb(255 255 255/20%);
-    box-shadow: inset 0 0 0 1px rgb(255 255 255/20%);
-    margin-left: -178px;
-    margin-top: -253px;
-    top: 50%;
-    left: 50%;
-    border-radius: 16px;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    -webkit-backdrop-filter: blur(16px) saturate(200%);
-    backdrop-filter: blur(16px) saturate(200%)
+	position:fixed;
+	height:auto;
+	width:356px;
+	background: linear-gradient(0deg, rgb(82 86 179 / 10%) 10%, rgb(82 86 179 / 80%) 100%);
+	box-shadow: inset 0 0 0 1px rgb(255 255 255 / 20%);
+	margin-left:-178px;
+	margin-top:-253px;
+	top:50%;
+	left:50%;
+	border-radius: 16px;
+	animation-name:fadeInUp;
+	animation-duration: .5s;
+	animation-iteration-count:1;
+	backdrop-filter: blur(16px) saturate(200%);
 }
 
 .mini-menu-ico-logo {
-    background: url("/img/icons/menu/logo-wide-dark.png") left center/180px no-repeat;
-    position: relative;
-    width: 200px;
-    height: 40px;
-    margin-left: 30px;
-    margin-top: 20px;
-    margin-bottom: 10px;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1
+	background:url("/img/icons/menu/logo-wide-dark.png") left center/180px no-repeat;
+	position:relative;
+	width:200px;
+	height:40px;
+	margin-left:30px;
+	margin-top:20px;
+	margin-bottom:10px;
+	animation-name:fadeInUp;
+	animation-duration:1s;
+	animation-iteration-count:1
 }
 
 .mini-menu-tx1-block {
-    margin-bottom: 10px;
-    margin-top: 10px;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px;
-    color: #fff
+	margin-bottom:10px;
+	margin-top:10px;
+	animation-name:fadeInUp;
+	animation-duration:1s;
+	animation-iteration-count:1;
+	color:#fff
 }
 
 .mini-menu-tx2-block {
-    margin-bottom: 20px;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    color: #fff
+	margin-bottom:20px;
+	animation-name:fadeInUp;
+	animation-duration:1s;
+	animation-iteration-count:1;
+	color:#fff
 }
 
 .mini-menu-tx1-block h2 {
@@ -276,37 +231,31 @@ a:hover {
 }
 
 .mini-menu-btn-agree {
-    font-family: Roboto-Bold;
-    line-height: 60px;
-    font-size: 18px;
-    text-align: center;
-    color: #000;
-    background: rgb(255 255 255/90%);
-    border: solid 2px #fff;
-    height: 60px;
-    cursor: pointer;
-    border-radius: 10px;
-    margin-left: 6px;
-    margin-right: 6px;
-    margin-bottom: 6px;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    bottom: 0
+	font-family:Roboto-Bold;
+	line-height:60px;
+	font-size:18px;
+	text-align:center;
+	color: #000;
+	background: rgb(255 255 255 / 90%);
+	border: solid 2px #fff;
+	height:60px;
+	cursor:pointer;
+	border-radius: 10px;
+	margin-left: 6px;
+	margin-right: 6px;
+	margin-bottom: 6px;
+	animation-name:fadeInUp;
+	animation-duration: .5s;
+	animation-iteration-count:1;
+	transition:all .1s ease-in-out 0s;
+	bottom:0;
 }
 
 .mini-menu-btn-agree:hover {
-    color: #fff;
-    border: solid 2px #878cff;
-    background: #686de0;
-    -webkit-box-shadow: rgb(104 109 224/50%) 0 0 64px 0;
-    box-shadow: rgb(104 109 224/50%) 0 0 64px 0
+	color: #fff;
+	border: solid 2px #878cff;
+	background:#686de0;
+	box-shadow:rgb(104 109 224 / 50%) 0 0 64px 0;
 }
 
 .menu-con-message {
@@ -318,87 +267,72 @@ a:hover {
 }
 
 .menu-tx1-message {
-    font-family: Roboto-Bold;
-    font-size: 14px;
-    line-height: 40px;
-    position: relative;
-    height: 40px;
-    text-align: center;
-    color: #fff;
-    background: rgba(255,52,52,.8);
-    -webkit-backdrop-filter: blur(4px);
-    backdrop-filter: blur(4px);
-    border-radius: 12px;
-    margin-left: 20px;
-    margin-right: 20px;
-    border: 2px solid rgba(255,52,52,.8);
-    -webkit-box-shadow: rgba(255,52,52,.4) 0 10px 32px 0;
-    box-shadow: rgba(255,52,52,.4) 0 10px 32px 0
+	font-family:Roboto-Bold;
+	font-size:14px;
+	line-height:40px;
+	position:relative;
+	height:40px;
+	text-align:center;
+	color:#fff;
+	background:rgba(255,52,52,.8);
+	backdrop-filter:blur(4px);
+	border-radius:12px;
+	margin-left:20px;
+	margin-right:20px;
+	border:2px solid rgba(255,52,52,.8);
+	box-shadow:rgba(255,52,52,.4) 0 10px 32px 0
 }
 
 .menu-btn-close {
-    border: 2px solid #fff;
-    position: fixed;
-    z-index: 12;
-    top: 20px;
-    left: 20px;
-    width: 40px;
-    height: 40px;
-    cursor: pointer;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    -webkit-animation-name: zoomIn;
-    animation-name: zoomIn;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    border-radius: 100%;
-    background-image: url(/img/icons/menu/close.png);
-    background-position: center center;
-    background-repeat: no-repeat;
-    background-attachment: initial;
-    background-origin: initial;
-    background-clip: initial;
-    background-color: #4e34c9;
-    -webkit-box-shadow: rgba(0,0,0,.05) 0 10px 16px 0;
-    box-shadow: rgba(0,0,0,.05) 0 10px 16px 0;
-    background-size: cover!important
+	border:2px solid #fff;
+	position:fixed;
+	z-index:12;
+	top:20px;
+	left:20px;
+	width:40px;
+	height:40px;
+	cursor:pointer;
+	transition:all .1s ease-in-out 0s;
+	animation-name:zoomIn;
+	animation-duration:.5s;
+	animation-iteration-count:1;
+	border-radius:100%;
+	background-image:url(/img/icons/menu/close.png);
+	background-position:center center;
+	background-repeat:no-repeat;
+	background-attachment:initial;
+	background-origin:initial;
+	background-clip:initial;
+	background-color:#4e34c9;
+	box-shadow:rgba(0,0,0,.05) 0 10px 16px 0;
+	background-size:cover!important
 }
 
 .menu-btn-close:hover {
-    -webkit-transform: scale(.9);
-    -ms-transform: scale(.9);
-    transform: scale(.9);
-    border-color: red;
-    background: url("/img/icons/menu/close.png") center center/cover no-repeat rgb(255,0,0)!important
+	transform:scale(.9);
+	border-color:red;
+	background:url("/img/icons/menu/close.png") center center/cover no-repeat rgb(255,0,0)!important
 }
 
 .menu-tx1-tooltip {
-    width: auto;
-    height: 30px;
-    font-family: Roboto-Regular;
-    font-size: 18px;
-    line-height: 16px;
-    color: #fff;
-    position: absolute;
-    top: 12px;
-    padding-left: 60px;
-    -webkit-animation-name: fadeIn;
-    animation-name: fadeIn;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    display: none
+	width:auto;
+	height:30px;
+	font-family:Roboto-Regular;
+	font-size:18px;
+	line-height:16px;
+	color:#fff;
+	position:absolute;
+	top:12px;
+	padding-left:60px;
+	animation-name:fadeIn;
+	animation-duration:.5s;
+	animation-iteration-count:1;
+	display:none
 }
 
 .menu-btn-close:hover>.menu-tx1-tooltip {
-    -webkit-transform: scale(1.1);
-    -ms-transform: scale(1.1);
-    transform: scale(1.1);
-    display: block!important
+	transform:scale(1.1);
+	display:block!important
 }
 
 .menu-con-logo {
@@ -411,14 +345,12 @@ a:hover {
 }
 
 .menu-ico-logo {
-    position: absolute;
-    width: 45px;
-    height: 70px;
-    border-bottom: 2px solid transparent;
-    background: url("/img/icons/menu/logo.png") center center/36px no-repeat;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	position:absolute;
+	width:45px;
+	height:70px;
+	border-bottom:2px solid transparent;
+	background:url("/img/icons/menu/logo.png") center center/36px no-repeat;
+	transition:all .1s ease-in-out 0s
 }
 
 .menu-ico-logo:hover {
@@ -427,28 +359,23 @@ a:hover {
 }
 
 .menu-con-container {
-    position: fixed;
-    z-index: 9997;
-    top: 0;
-    width: 100%;
-    height: auto;
-    background: rgba(255,255,255,.05);
-    -webkit-backdrop-filter: blur(16px);
-    backdrop-filter: blur(16px);
-    border-bottom: 1px solid rgba(255,255,255,.1);
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none
+	position:fixed;
+	z-index:9997;
+	top:0;
+	width:100%;
+	height:auto;
+	background:rgba(255,255,255,.05);
+	backdrop-filter:blur(6px);
+	border-bottom:1px solid rgba(255,255,255,.1);
+	user-select:none
 }
 
 .menu-con-backdrop {
-    position: absolute;
-    display: none;
-    width: 100%;
-    height: 100%;
-    background: -o-linear-gradient(225deg,rgba(0,42,135,0.8) 25%,rgba(147,64,255,0.8) 100%);
-    background: linear-gradient(-135deg,rgba(0,42,135,0.8) 25%,rgba(147,64,255,0.8) 100%)
+	position:absolute;
+	display:none;
+	width:100%;
+	height:100%;
+	background:linear-gradient(-135deg,rgba(0,42,135,0.8) 25%,rgba(147,64,255,0.8) 100%)
 }
 
 .menu-con-outer {
@@ -469,23 +396,21 @@ a:hover {
 }
 
 .menu-btn-select {
-    font-family: Roboto-Regular;
-    font-size: 16px;
-    line-height: 70px;
-    position: relative;
-    top: 0;
-    display: inline-block;
-    width: auto;
-    height: 70px;
-    padding-right: 12px;
-    padding-left: 12px;
-    margin-bottom: -2px;
-    color: #fff;
-    border-bottom: 2px solid transparent;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px
+	font-family:Roboto-Regular;
+	font-size:16px;
+	line-height:70px;
+	position:relative;
+	top:0;
+	display:inline-block;
+	width:auto;
+	height:70px;
+	padding-right:12px;
+	padding-left:12px;
+	margin-bottom:-2px;
+	color:#fff;
+	border-bottom:2px solid transparent;
+	transition:all .1s ease-in-out 0s;
+	text-shadow:rgba(0,0,0,.25) 0 2px 2px
 }
 
 .menu-btn-select:hover {
@@ -494,29 +419,25 @@ a:hover {
 }
 
 .menu-btn-backtotop {
-    background: url("/img/icons/buttons/backtotop.png") center center/24px no-repeat rgb(255,255,255);
-    width: 44px;
-    height: 44px;
-    position: fixed;
-    border-radius: 100%;
-    bottom: 20px;
-    right: 20px;
-    -webkit-box-shadow: rgba(0,0,0,.2) 0 10px 32px 0;
-    box-shadow: rgba(0,0,0,.2) 0 10px 32px 0;
-    z-index: 9999;
-    cursor: pointer;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    display: none;
-    border: 2px solid #fff
+	background:url("/img/icons/buttons/backtotop.png") center center/24px no-repeat rgb(255,255,255);
+	width:44px;
+	height:44px;
+	position:fixed;
+	border-radius:100%;
+	bottom:20px;
+	right:20px;
+	box-shadow:rgba(0,0,0,.2) 0 10px 32px 0;
+	z-index:9999;
+	cursor:pointer;
+	transition:all .1s ease-in-out 0s;
+	display:none;
+	border:2px solid #fff
 }
 
 .menu-btn-backtotop:hover {
-    background: url("/img/icons/buttons/backtotop-h.png") center center/24px no-repeat rgb(26,188,156);
-    -webkit-box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    border: 2px solid #57e694
+	background:url("/img/icons/buttons/backtotop-h.png") center center/24px no-repeat rgb(26,188,156);
+	box-shadow:rgba(46,204,113,.4) 0 10px 32px 0;
+	border:2px solid #57e694
 }
 
 .menu-con-divider {
@@ -570,34 +491,32 @@ a:hover {
 }
 
 .menu-con-release {
-    position: fixed;
-    width: auto;
-    height: 24px;
-    background: rgba(0,0,0,.1);
-    z-index: 1111;
-    bottom: 16px;
-    left: 16px;
-    font-family: Roboto-Regular;
-    font-size: 14px;
-    color: #fff;
-    line-height: 24px;
-    border-radius: 22px;
-    padding: 2px 14px;
-    -webkit-backdrop-filter: blur(6px);
-    backdrop-filter: blur(6px);
-    border: solid 1px rgb(255 255 255/20%);
-    display: none
+	position:fixed;
+	width:auto;
+	height:24px;
+	background:rgba(0,0,0,.1);
+	z-index:1111;
+	bottom:16px;
+	left:16px;
+	font-family:Roboto-Regular;
+	font-size:14px;
+	color:#fff;
+	line-height:24px;
+	border-radius:22px;
+	padding:2px 14px;
+	backdrop-filter:blur(6px);
+	border:solid 1px rgb(255 255 255/20%);
+	display:none;
 }
 
 .mobile-menu-con-container {
-    position: fixed;
-    z-index: 8990;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(17,21,37,.9);
-    -webkit-backdrop-filter: blur(14px);
-    backdrop-filter: blur(14px)
+	position:fixed;
+	z-index:8990;
+	top:0;
+	width:100%;
+	height:100%;
+	background:rgba(17,21,37,.9);
+	backdrop-filter:blur(14px)
 }
 
 .mobile-menu-con-outter {
@@ -615,29 +534,25 @@ a:hover {
 }
 
 .mobile-menu-btn-select {
-    font-family: Roboto-Regular;
-    font-size: 18px;
-    line-height: 50px;
-    position: relative;
-    height: 50px;
-    padding-left: 20px;
-    color: #fff;
-    -webkit-animation-name: fadeInDown;
-    animation-name: fadeInDown;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    border-radius: 6px;
-    margin-bottom: 10px;
-    border: 2px solid rgba(255,255,255,.03)
+	font-family:Roboto-Regular;
+	font-size:18px;
+	line-height:50px;
+	position:relative;
+	height:50px;
+	padding-left:20px;
+	color:#fff;
+	animation-name:fadeInDown;
+	animation-duration:.5s;
+	animation-iteration-count:1;
+	border-radius:6px;
+	margin-bottom:10px;
+	border:2px solid rgba(255,255,255,.03)
 }
 
 .mobile-menu-btn-select:hover {
-    color: #4e34c9;
-    -webkit-box-shadow: rgba(0,0,0,.1) 10px 10px 32px 0;
-    box-shadow: rgba(0,0,0,.1) 10px 10px 32px 0;
-    background: rgba(255,255,255,.9)!important
+	color:#4e34c9;
+	box-shadow:rgba(0,0,0,.1) 10px 10px 32px 0;
+	background:rgba(255,255,255,.9)!important
 }
 
 .mobile-menu-con-scroll::-webkit-scrollbar {
@@ -658,51 +573,40 @@ a:hover {
 }
 
 .mobile-menu-tx1-group {
-    font-family: Roboto-Regular;
-    font-size: 16px;
-    line-height: 20px;
-    color: rgba(255,255,255,.5);
-    height: 20px;
-    position: relative;
-    margin-top: 20px;
-    -webkit-animation-name: fadeInDown;
-    animation-name: fadeInDown;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1
+	font-family:Roboto-Regular;
+	font-size:16px;
+	line-height:20px;
+	color:rgba(255,255,255,.5);
+	height:20px;
+	position:relative;
+	margin-top:20px;
+	animation-name:fadeInDown;
+	animation-duration:.5s;
+	animation-iteration-count:1
 }
 
 .mobile-menu-con-divider {
-    width: 100%;
-    height: 2px;
-    border-radius: 2px;
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgba(255,255,255,0.5)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgba(255,255,255,0.5));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgba(255,255,255,0.5));
-    margin-top: 10px;
-    margin-bottom: 30px;
-    position: relative;
-    -webkit-animation-name: fadeInRight;
-    animation-name: fadeInRight;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1
+	width:100%;
+	height:2px;
+	border-radius:2px;
+	background:linear-gradient(to left,rgba(255,255,255,0),rgba(255,255,255,0.5));
+	margin-top:10px;
+	margin-bottom:30px;
+	position:relative;
+	animation-name:fadeInRight;
+	animation-duration:.5s;
+	animation-iteration-count:1
 }
 
 .mobile-menu-btn-icon {
-    width: 50px;
-    height: 54px;
-    background: url("/img/icons/arrows/left-h.png") center center/18px no-repeat;
-    position: relative;
-    -webkit-animation-name: fadeInDown;
-    animation-name: fadeInDown;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    float: left
+	width:50px;
+	height:54px;
+	background:url("/img/icons/arrows/left-h.png") center center/18px no-repeat;
+	position:relative;
+	animation-name:fadeInDown;
+	animation-duration:.5s;
+	animation-iteration-count:1;
+	float:left
 }
 
 .mobile-menu-btn-spacer {
@@ -711,24 +615,19 @@ a:hover {
 }
 
 .menu-btn-settings {
-    position: absolute;
-    z-index: 9998;
-    top: 0;
-    right: 0;
-    width: 70px;
-    height: 100%;
-    cursor: pointer;
-    border-bottom: 2px solid transparent;
-    background: url("/img/icons/menu/settings.png") center center/28px no-repeat;
-    -webkit-animation-name: fadeIn;
-    animation-name: fadeIn;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	position:absolute;
+	z-index:9998;
+	top:0;
+	right:0;
+	width:70px;
+	height:100%;
+	cursor:pointer;
+	border-bottom:2px solid transparent;
+	background:url("/img/icons/menu/settings.png") center center/28px no-repeat;
+	animation-name:fadeIn;
+	animation-duration:.5s;
+	animation-iteration-count:1;
+	transition:all .1s ease-in-out 0s
 }
 
 .menu-btn-settings:hover {
@@ -770,40 +669,33 @@ a:hover {
 }
 
 .settings-menu-con-outer {
-    z-index: 9999;
-    position: fixed;
-    top: 80px;
-    right: 8px;
-    display: none;
-    width: 222px;
-    height: 390px;
-    -webkit-box-shadow: rgba(0,0,0,.2) 0 0 80px 0;
-    box-shadow: rgba(0,0,0,.2) 0 0 80px 0;
-    border-radius: 16px;
-    -webkit-animation-name: fadeInRight;
-    animation-name: fadeInRight;
-    -webkit-animation-duration: .2s;
-    animation-duration: .2s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    -webkit-backdrop-filter: blur(32px) saturate(200%);
-    backdrop-filter: blur(32px) saturate(200%);
-    border: 1px solid rgba(255,255,255,.1);
-    background: rgba(17,21,37,.6)!important
+	z-index:9999;
+	position:fixed;
+	top:80px;
+	right:8px;
+	display:none;
+	width:222px;
+	height:390px;
+	box-shadow:rgba(0,0,0,.2) 0 0 80px 0;
+	border-radius:16px;
+	animation-name:fadeInRight;
+	animation-duration:.2s;
+	animation-iteration-count:1;
+	backdrop-filter:blur(32px) saturate(500%);
+	border:1px solid rgba(255,255,255,.1);
+	background:rgba(17,21,37,.6)!important
 }
 
 .settings-menu-con-wrapper {
-    position: relative;
-    width: 100%;
-    height: 64px;
-    cursor: pointer;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	position:relative;
+	width:100%;
+	height:64px;
+	cursor:pointer;
+	transition:all .1s ease-in-out 0s
 }
 
 .settings-menu-upper {
-    border-radius: 15px 15px 0 0
+	border-radius:15px 15px 0 0
 }
 
 .settings-menu-lower {
@@ -811,9 +703,8 @@ a:hover {
 }
 
 .settings-menu-con-wrapper:hover {
-    background: #03a9f4;
-    -webkit-box-shadow: rgb(3 169 244/50%) 0 0 32px 0;
-    box-shadow: rgb(3 169 244/50%) 0 0 32px 0
+	background:#03A9F4;
+	box-shadow:rgb(3 169 244 / 50%) 0 0 32px 0
 }
 
 .settings-menu-con-wrapper:hover .settings-menu-btn-button {
@@ -830,128 +721,121 @@ a:hover {
 }
 
 .settings-menu-btn-button {
-    font-family: Roboto-Regular;
-    font-size: 14px;
-    line-height: 64px;
-    position: relative;
-    display: inline-block;
-    float: left;
-    width: auto;
-    height: 64px;
-    text-align: left;
-    pointer-events: none;
-    color: #fff;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px
+	font-family:Roboto-Regular;
+	font-size:14px;
+	line-height:64px;
+	position:relative;
+	display:inline-block;
+	float:left;
+	width:auto;
+	height:64px;
+	text-align:left;
+	pointer-events:none;
+	text-shadow: rgba(0,0,0,.25) 0 2px 2px;
+	color:#fff
 }
 
 .settings-menu-ico-darkmode {
-    display: inline-block;
-    float: left;
-    width: 42px;
-    height: 42px;
-    margin-top: 10px;
-    margin-left: 10px;
-    margin-right: 10px;
-    border-radius: 100%;
-    background: rgb(255 255 255/10%) url("/img/icons/submenu/darkmode-h.png") center center/20px no-repeat;
-    border: solid 1px rgb(255 255 255/10%)
+	display:inline-block;
+	float:left;
+	width:42px;
+	height:42px;
+	margin-top:10px;
+	margin-left:10px;
+	margin-right:10px;
+	border-radius:100%;
+	border:solid 1px rgb(255 255 255/10%);
+	background:rgb(255 255 255/10%) url("/img/icons/submenu/darkmode-h.png") center center/20px no-repeat;
 }
 
 .settings-menu-ico-particles {
-    display: inline-block;
-    float: left;
-    width: 42px;
-    height: 42px;
-    margin-top: 10px;
-    margin-left: 10px;
-    margin-right: 10px;
-    border-radius: 100%;
-    background: rgb(255 255 255/10%) url("/img/icons/submenu/particles-h.png") center center/20px no-repeat;
-    border: solid 1px rgb(255 255 255/10%)
+	display:inline-block;
+	float:left;
+	width:42px;
+	height:42px;
+	margin-top:10px;
+	margin-left:10px;
+	margin-right:10px;
+	border-radius:100%;
+	border:solid 1px rgb(255 255 255/10%);
+	background:rgb(255 255 255/10%) url("/img/icons/submenu/particles-h.png") center center/20px no-repeat;
 }
 
 .settings-menu-ico-pulsate {
-    display: inline-block;
-    float: left;
-    width: 42px;
-    height: 42px;
-    margin-top: 10px;
-    margin-left: 10px;
-    margin-right: 10px;
-    border-radius: 100%;
-    background: rgb(255 255 255/10%) url(/img/icons/submenu/pulsate-h.png) center center/20px no-repeat;
-    border: solid 1px rgb(255 255 255/10%)
+	display:inline-block;
+	float:left;
+	width:42px;
+	height:42px;
+	margin-top:10px;
+	margin-left:10px;
+	margin-right:10px;
+	border-radius:100%;
+	border:solid 1px rgb(255 255 255/10%);
+	background:rgb(255 255 255/10%) url(/img/icons/submenu/pulsate-h.png) center center/20px no-repeat;
 }
 
 .settings-menu-ico-waves {
-    display: inline-block;
-    float: left;
-    width: 42px;
-    height: 42px;
-    margin-top: 10px;
-    margin-left: 10px;
-    margin-right: 10px;
-    border-radius: 100%;
-    background: rgb(255 255 255/10%) url(/img/icons/submenu/waves-h.png) center center/20px no-repeat;
-    border: solid 1px rgb(255 255 255/10%)
+	display:inline-block;
+	float:left;
+	width:42px;
+	height:42px;
+	margin-top:10px;
+	margin-left:10px;
+	margin-right:10px;
+	border-radius:100%;
+	border:solid 1px rgb(255 255 255/10%);
+	background:rgb(255 255 255/10%) url(/img/icons/submenu/waves-h.png) center center/20px no-repeat;
 }
 
 .settings-menu-ico-transparency {
-    display: inline-block;
-    float: left;
-    width: 42px;
-    height: 42px;
-    margin-top: 10px;
-    margin-left: 10px;
-    margin-right: 10px;
-    border-radius: 100%;
-    background: rgb(255 255 255/10%) url("/img/icons/submenu/transparency-h.png") center center/20px no-repeat;
-    border: solid 1px rgb(255 255 255/10%)
+	display:inline-block;
+	float:left;
+	width:42px;
+	height:42px;
+	margin-top:10px;
+	margin-left:10px;
+	margin-right:10px;
+	border-radius:100%;
+	border:solid 1px rgb(255 255 255/10%);
+	background:rgb(255 255 255/10%) url("/img/icons/submenu/transparency-h.png") center center/20px no-repeat;
 }
 
 .settings-menu-ico-theme {
-    display: inline-block;
-    float: left;
-    width: 42px;
-    height: 42px;
-    margin-top: 10px;
-    margin-left: 10px;
-    margin-right: 10px;
-    border-radius: 100%;
-    background: rgb(255 255 255/10%) url(/img/icons/submenu/theme-h.png) center center/20px no-repeat;
-    border: solid 1px rgb(255 255 255/10%)
+	display:inline-block;
+	float:left;
+	width:42px;
+	height:42px;
+	margin-top:10px;
+	margin-left:10px;
+	margin-right:10px;
+	border-radius:100%;
+	background:rgb(255 255 255/10%) url(/img/icons/submenu/theme-h.png) center center/20px no-repeat;
+	border:solid 1px rgb(255 255 255/10%);
 }
 
 .support-con-menu {
-    position: relative;
-    top: 0;
-    display: inline-block;
-    float: right;
-    width: 120px;
-    height: 70px;
-    margin-bottom: -2px;
-    border-bottom: 2px solid transparent;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	position:relative;
+	top:0;
+	display:inline-block;
+	float:right;
+	width:120px;
+	height:70px;
+	margin-bottom:-2px;
+	border-bottom:2px solid transparent;
+	transition:all .1s ease-in-out 0s
 }
 
 .support-ico-menu {
-    position: absolute;
-    right: 0;
-    width: 120px;
-    height: 70px;
-    background: url("/img/icons/services/patreon.png") center center/contain no-repeat;
-    cursor: pointer;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    -webkit-animation-name: fadeInRight;
-    animation-name: fadeInRight;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1
+	position:absolute;
+	right:0;
+	width:120px;
+	height:70px;
+	background:url("/img/icons/services/patreon.png") center center/contain no-repeat;
+	cursor:pointer;
+	transition:all .1s ease-in-out 0s;
+	animation-name:fadeInRight;
+	animation-duration:.5s;
+	animation-iteration-count:1
 }
 
 .support-ico-menu:hover {
@@ -968,36 +852,29 @@ a:hover {
 }
 
 .support-con-outer {
-    position: absolute;
-    top: 80px;
-    left: -58px;
-    display: none;
-    width: 228px;
-    height: 261px;
-    -webkit-box-shadow: rgba(0,0,0,.2) 0 0 80px 0;
-    box-shadow: rgba(0,0,0,.2) 0 0 80px 0;
-    border-radius: 12px;
-    border: 2px solid rgba(255,255,255,.1);
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: .2s;
-    animation-duration: .2s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    -webkit-backdrop-filter: blur(12px) saturate(500%);
-    backdrop-filter: blur(12px) saturate(500%);
-    background: rgba(17,21,37,.8)!important
+	position:absolute;
+	top:80px;
+	left:-58px;
+	display:none;
+	width:228px;
+	height:261px;
+	box-shadow:rgba(0,0,0,.2) 0 0 80px 0;
+	border-radius:12px;
+	border:2px solid rgba(255,255,255,.1);
+	animation-name:fadeInUp;
+	animation-duration:.2s;
+	animation-iteration-count:1;
+	backdrop-filter:blur(12px) saturate(500%);
+	background:rgba(17,21,37,.8)!important
 }
 
 .support-con-wrapper {
-    position: relative;
-    width: 100%;
-    height: 64px;
-    border-bottom: 1px solid rgba(0,0,0,.05);
-    cursor: pointer;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	position:relative;
+	width:100%;
+	height:64px;
+	border-bottom:1px solid rgba(0,0,0,.05);
+	cursor:pointer;
+	transition:all .1s ease-in-out 0s
 }
 
 .support-upper {
@@ -1009,9 +886,8 @@ a:hover {
 }
 
 .support-con-wrapper:hover {
-    background: #1abc9c;
-    -webkit-box-shadow: rgba(26,188,156,.5) 0 0 32px 0;
-    box-shadow: rgba(26,188,156,.5) 0 0 32px 0
+	background:#1abc9c;
+	box-shadow:rgba(26,188,156,.5) 0 0 32px 0
 }
 
 .support-con-wrapper:hover .support-btn-button {
@@ -1045,36 +921,30 @@ a:hover {
 }
 
 .support-ico-patreon {
-    display: inline-block;
-    float: left;
-    width: 64px;
-    height: 64px;
-    background: url("/img/icons/submenu/patreon.png") center center/28px no-repeat;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	display:inline-block;
+	float:left;
+	width:64px;
+	height:64px;
+	background:url("/img/icons/submenu/patreon.png") center center/28px no-repeat;
+	transition:all .1s ease-in-out 0s
 }
 
 .support-ico-github {
-    display: inline-block;
-    float: left;
-    width: 64px;
-    height: 64px;
-    background: url("/img/icons/submenu/code-h.png") center center/28px no-repeat;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	display:inline-block;
+	float:left;
+	width:64px;
+	height:64px;
+	background:url("/img/icons/submenu/code-h.png") center center/28px no-repeat;
+	transition:all .1s ease-in-out 0s
 }
 
 .support-ico-testing {
-    display: inline-block;
-    float: left;
-    width: 64px;
-    height: 64px;
-    background: url("/img/icons/submenu/testing-h.png") center center/28px no-repeat;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	display:inline-block;
+	float:left;
+	width:64px;
+	height:64px;
+	background:url("/img/icons/submenu/testing-h.png") center center/28px no-repeat;
+	transition:all .1s ease-in-out 0s
 }
 
 .window-con-theme {
@@ -1088,12 +958,11 @@ a:hover {
 }
 
 .window-bg-theme {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    background: -o-linear-gradient(225deg,rgb(135,0,93) 25%,rgb(255,64,64) 100%);
-    background: linear-gradient(-135deg,rgb(135,0,93) 25%,rgb(255,64,64) 100%);
-    display: none
+	width:100%;
+	height:100%;
+	position:absolute;
+	background:linear-gradient(-135deg,rgb(135,0,93) 25%,rgb(255,64,64) 100%);
+	display:none
 }
 
 .theme-btn-close {
@@ -1141,36 +1010,31 @@ a:hover {
 }
 
 .theme-ico-spinner {
-    background: url("/img/icons/menu/loading.png") center center/46px no-repeat;
-    width: 100px;
-    height: 100px;
-    position: absolute;
-    -webkit-animation: 1s linear 0s infinite normal none running spinnerRotate;
-    animation: 1s linear 0s infinite normal none running spinnerRotate
+	background:url("/img/icons/menu/loading.png") center center/46px no-repeat;
+	width:100px;
+	height:100px;
+	position:absolute;
+	animation:1s linear 0s infinite normal none running spinnerRotate
 }
 
 .sidebar-con-container {
-    position: relative;
-    -webkit-animation-name: fadeInLeft;
-    animation-name: fadeInLeft;
-    -webkit-animation-duration: .3s;
-    animation-duration: .3s;
-    margin-top: 10px
+	position:relative;
+	animation-name:fadeInLeft;
+	animation-duration:.3s;
+	margin-top:10px
 }
 
 .sidebar-btn-open {
-    position: fixed;
-    z-index: 9998;
-    top: 0;
-    left: 0;
-    width: 70px;
-    height: 70px;
-    cursor: pointer;
-    border-bottom: 2px solid transparent;
-    background: url("/img/icons/menu/menu.png") center center/18px no-repeat;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	position:fixed;
+	z-index:9998;
+	top:0;
+	left:0;
+	width:70px;
+	height:70px;
+	cursor:pointer;
+	border-bottom:2px solid transparent;
+	background:url("/img/icons/menu/menu.png") center center/18px no-repeat;
+	transition:all .1s ease-in-out 0s
 }
 
 .sidebar-btn-open:hover {
@@ -1201,30 +1065,23 @@ a:hover {
 }
 
 .sidebar-con-anim {
-    z-index: 9999;
-    overflow: hidden scroll;
-    width: 378px;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    -webkit-animation-name: fadeInLeft;
-    animation-name: fadeInLeft;
-    -webkit-animation-duration: .2s;
-    animation-duration: .2s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    -webkit-backdrop-filter: blur(12px) saturate(500%);
-    backdrop-filter: blur(12px) saturate(500%);
-    -webkit-box-shadow: rgba(0,0,0,.2) 20px 20px 64px 0;
-    box-shadow: rgba(0,0,0,.2) 20px 20px 64px 0;
-    display: block;
-    position: fixed;
-    height: auto;
-    inset: 0;
-    margin: 20px;
-    border-radius: 12px;
-    border: 1px solid rgba(255,255,255,.1);
-    background: rgba(17,21,37,.9)!important
+	z-index:9999;
+	overflow:hidden scroll;
+	width:378px;
+	transition:all .2s ease-in-out 0s;
+	animation-name:fadeInLeft;
+	animation-duration:.2s;
+	animation-iteration-count:1;
+	backdrop-filter:blur(12px) saturate(500%);
+	box-shadow:rgba(0,0,0,.2) 20px 20px 64px 0;
+	display:block;
+	position:fixed;
+	height:auto;
+	inset:0;
+	margin:20px;
+	border-radius:12px;
+	border:1px solid rgba(255,255,255,.1);
+	background:rgba(17,21,37,.9)!important
 }
 
 .sidebar-con-anim::-webkit-scrollbar {
@@ -1272,19 +1129,17 @@ a:hover {
 }
 
 .sidebar-tx2-subtitle {
-    font-family: Roboto-Regular;
-    font-size: 14px;
-    line-height: 40px;
-    position: relative;
-    height: 40px;
-    margin-left: 40px;
-    padding-left: 16px;
-    text-align: left;
-    border-left: 1px solid rgba(255,255,255,.2);
-    color: rgba(255,255,255,.5);
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	font-family:Roboto-Regular;
+	font-size:14px;
+	line-height:40px;
+	position:relative;
+	height:40px;
+	margin-left:40px;
+	padding-left:16px;
+	text-align:left;
+	border-left:1px solid rgba(255,255,255,.2);
+	color:rgba(255,255,255,.5);
+	transition:all .1s ease-in-out 0s
 }
 
 .sidebar-tx2-subtitle:hover {
@@ -1299,30 +1154,23 @@ a:hover {
 }
 
 .blogbar-con-anim {
-    z-index: 9999;
-    overflow: hidden scroll;
-    width: 378px;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    -webkit-animation-name: fadeInLeft;
-    animation-name: fadeInLeft;
-    -webkit-animation-duration: .2s;
-    animation-duration: .2s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    -webkit-backdrop-filter: blur(12px) saturate(500%);
-    backdrop-filter: blur(12px) saturate(500%);
-    -webkit-box-shadow: rgba(0,0,0,.2) 20px 20px 64px 0;
-    box-shadow: rgba(0,0,0,.2) 20px 20px 64px 0;
-    display: block;
-    position: fixed;
-    height: auto;
-    inset: 0;
-    margin: 20px;
-    border-radius: 12px;
-    border: 1px solid rgba(255,255,255,.1);
-    background: rgba(17,21,37,.9)!important
+	z-index:9999;
+	overflow:hidden scroll;
+	width:378px;
+	transition:all .2s ease-in-out 0s;
+	animation-name:fadeInLeft;
+	animation-duration:.2s;
+	animation-iteration-count:1;
+	backdrop-filter:blur(12px) saturate(500%);
+	box-shadow:rgba(0,0,0,.2) 20px 20px 64px 0;
+	display:block;
+	position:fixed;
+	height:auto;
+	inset:0;
+	margin:20px;
+	border-radius:12px;
+	border:1px solid rgba(255,255,255,.1);
+	background:rgba(17,21,37,.9)!important
 }
 
 .blogbar-con-anim::-webkit-scrollbar {
@@ -1344,21 +1192,19 @@ a:hover {
 }
 
 .banner-con-container {
-    position: relative;
-    z-index: 2;
-    overflow: hidden;
-    width: 100%;
-    height: 380px;
-    background: -o-linear-gradient(225deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%);
-    background: linear-gradient(-135deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%)
+	position:relative;
+	z-index:2;
+	overflow:hidden;
+	width:100%;
+	height:380px;
+	background:linear-gradient(-135deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%)
 }
 
 .banner-con-backdrop {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    background: -o-linear-gradient(225deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%);
-    background: linear-gradient(-135deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%)
+	position:absolute;
+	width:100%;
+	height:100%;
+	background:linear-gradient(-135deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%)
 }
 
 .banner-con-title {
@@ -1513,35 +1359,30 @@ a:hover {
 }
 
 .container-con-superblock-div {
-    width: 100%;
-    height: 2px;
-    position: relative;
-    border-radius: 2px;
-    margin-bottom: 12px;
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(104,109,224)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(104,109,224));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(104,109,224))
+	width:100%;
+	height:2px;
+	position:relative;
+	border-radius:2px;
+	margin-bottom:12px;
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(104,109,224));
 }
 
 .splitter-con-container {
-    position: relative;
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex
+	position:relative;
+	display:flex
 }
 
 .splitter-img-container {
-    position: relative;
-    width: 50%;
-    display: inline-block;
-    float: right;
-    border-radius: 16px;
-    overflow: hidden;
-    margin-top: 40px;
-    margin-bottom: 20px;
-    -webkit-box-shadow: rgba(0,0,0,.2) 20px 20px 64px 0;
-    box-shadow: rgba(0,0,0,.2) 20px 20px 64px 0;
-    border: solid 1px rgb(255 255 255/10%)
+	position:relative;
+	width:50%;
+	display:inline-block;
+	float:right;
+	border-radius:16px;
+	overflow:hidden;
+	margin-top:40px;
+	margin-bottom:20px;
+	box-shadow:rgba(0,0,0,.2) 20px 20px 64px 0;
+	border:solid 1px rgb(255 255 255/10%)
 }
 
 .splitter-img-wrapper {
@@ -1579,32 +1420,26 @@ a:hover {
 }
 
 .generic-btn-button {
-    width: auto;
-    height: 46px;
-    border-radius: 46px;
-    background: -o-linear-gradient(225deg,rgb(73,164,255) 25%,rgb(0,116,231) 100%);
-    background: linear-gradient(-135deg,rgb(73,164,255) 25%,rgb(0,116,231) 100%);
-    cursor: pointer;
-    padding-left: 4px;
-    padding-right: 16px;
-    display: inline-block;
-    margin-right: 20px;
-    margin-bottom: 15px;
-    -webkit-box-shadow: rgba(0,116,231,.4) 0 10px 32px 0;
-    box-shadow: rgba(0,116,231,.4) 0 10px 32px 0;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    border: 1px solid #0080ff!important;
-    position: relative
+	width:auto;
+	height:46px;
+	border-radius:46px;
+	background:linear-gradient(-135deg,rgb(73,164,255) 25%,rgb(0,116,231) 100%);
+	cursor:pointer;
+	padding-left:4px;
+	padding-right:16px;
+	display:inline-block;
+	margin-right:20px;
+	margin-bottom:15px;
+	box-shadow:rgba(0,116,231,.4) 0 10px 32px 0;
+	transition:all .1s ease-in-out 0s;
+	border:1px solid #0080ff!important;
+	position:relative
 }
 
 .generic-btn-button:hover {
-    background: -o-linear-gradient(225deg,rgb(46,204,113) 25%,rgb(26,188,156) 100%);
-    background: linear-gradient(-135deg,rgb(46,204,113) 25%,rgb(26,188,156) 100%);
-    -webkit-box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    border: 1px solid #57e694!important
+	background:linear-gradient(-135deg,rgb(46,204,113) 25%,rgb(26,188,156) 100%);
+	box-shadow:rgba(46,204,113,.4) 0 10px 32px 0;
+	border:1px solid #57e694!important
 }
 
 .generic-ico-button {
@@ -1651,26 +1486,22 @@ a:hover {
 }
 
 .spec-con-max {
-    width: 49%;
-    height: auto;
-    display: block;
-    float: left;
-    background: -webkit-gradient(linear,left bottom,left top,color-stop(10%,rgb(0 0 0/0%)),to(rgb(26 188 156/20%)));
-    background: -o-linear-gradient(bottom,rgb(0 0 0/0%) 10%,rgb(26 188 156/20%) 100%);
-    background: linear-gradient(0deg,rgb(0 0 0/0%) 10%,rgb(26 188 156/20%) 100%);
-    border-radius: 12px;
-    margin-right: 2%
+	width:49%;
+	height:auto;
+	display:block;
+	float:left;
+	background:linear-gradient(0deg,rgb(0 0 0/0%) 10%,rgb(26 188 156/20%) 100%);
+	border-radius:12px;
+	margin-right:2%
 }
 
 .spec-con-min {
-    width: 49%;
-    height: auto;
-    display: block;
-    float: left;
-    background: -webkit-gradient(linear,left bottom,left top,color-stop(10%,rgb(0 0 0/0%)),to(rgb(255 155 67/20%)));
-    background: -o-linear-gradient(bottom,rgb(0 0 0/0%) 10%,rgb(255 155 67/20%) 100%);
-    background: linear-gradient(0deg,rgb(0 0 0/0%) 10%,rgb(255 155 67/20%) 100%);
-    border-radius: 16px
+	width:49%;
+	height:auto;
+	display:block;
+	float:left;
+	background:linear-gradient(0deg,rgb(0 0 0/0%) 10%,rgb(255 155 67/20%) 100%);
+	border-radius:16px;
 }
 
 .spec-con-title {
@@ -1682,19 +1513,19 @@ a:hover {
 }
 
 .spec-max {
-    background: #1abc9c;
-    -webkit-box-shadow: rgba(0,0,0,.1) 10px 10px 32px 0;
-    box-shadow: rgba(0,0,0,.1) 10px 10px 32px 0;
-    margin-bottom: 10px;
-    overflow: hidden
+	background:#1abc9c;
+	border:solid 1px rgb(255 255 255/60%);
+	box-shadow:rgba(0,0,0,.1) 10px 10px 32px 0;
+	margin-bottom:10px;
+	overflow:hidden
 }
 
 .spec-min {
-    background: #ff9b43;
-    -webkit-box-shadow: rgba(0,0,0,.1) 10px 10px 32px 0;
-    box-shadow: rgba(0,0,0,.1) 10px 10px 32px 0;
-    margin-bottom: 10px;
-    overflow: hidden
+	background:#ff9b43;
+	border:solid 1px rgb(255 255 255/60%);
+	box-shadow:rgba(0,0,0,.1) 10px 10px 32px 0;
+	margin-bottom:10px;
+	overflow:hidden
 }
 
 .spec-img-hardware {
@@ -1755,14 +1586,12 @@ a:hover {
 }
 
 .spec-con-divider {
-    margin: 0 16px;
-    height: 2px;
-    border-radius: 2px;
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgba(0,0,0,0.05)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgba(0,0,0,0.05));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgba(0,0,0,0.05));
-    margin-top: 30px;
-    margin-bottom: 30px
+	margin:0 16px;
+	height:2px;
+	border-radius:2px;
+	background:linear-gradient(to left,rgba(255,255,255,0),rgba(0,0,0,0.05));
+	margin-top:30px;
+	margin-bottom:30px
 }
 
 .spec-con-item {
@@ -1781,16 +1610,15 @@ a:hover {
 }
 
 .item-ico-text {
-    width: 28px;
-    height: 28px;
-    position: relative;
-    top: 0;
-    float: left;
-    border-radius: 16px;
-    padding: 10px;
-    -webkit-box-shadow: rgb(0 0 0/10%) 0 10px 32px 0;
-    box-shadow: rgb(0 0 0/10%) 0 10px 32px 0;
-    border: solid 1px rgb(255 255 255/10%)
+	width:28px;
+	height:28px;
+	position:relative;
+	top:0;
+	float:left;
+	border-radius:16px;
+	padding:10px;
+	box-shadow:rgb(0 0 0/10%) 0 10px 32px 0;
+	border:solid 1px rgb(255 255 255/10%)
 }
 
 .item-ico-dynamic-a,.item-ico-dynamic-b {
@@ -1853,51 +1681,40 @@ a:hover {
 }
 
 .content-con-backdrop {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    background: -o-linear-gradient(225deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%);
-    background: linear-gradient(-135deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%)
+	position:absolute;
+	width:100%;
+	height:100%;
+	background:linear-gradient(-135deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%)
 }
 
 .content-btn-left {
-    position: absolute;
-    top: 50%;
-    left: -80px;
-    width: 100px;
-    height: 100px;
-    margin-top: -50px;
-    background: url("/img/icons/arrows/left.png") center center/64px no-repeat;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    -webkit-animation-name: drifting-left;
-    animation-name: drifting-left;
-    -webkit-animation-duration: 2s;
-    animation-duration: 2s;
-    -webkit-animation-iteration-count: infinite;
-    animation-iteration-count: infinite;
-    z-index: 4
+	position:absolute;
+	top:50%;
+	left:-80px;
+	width:100px;
+	height:100px;
+	margin-top:-50px;
+	background:url("/img/icons/arrows/left.png") center center/64px no-repeat;
+	transition:all .1s ease-in-out 0s;
+	animation-name:drifting-left;
+	animation-duration:2s;
+	animation-iteration-count:infinite;
+	z-index:4
 }
 
 .content-btn-right {
-    position: absolute;
-    top: 50%;
-    right: -80px;
-    width: 100px;
-    height: 100px;
-    margin-top: -50px;
-    background: url("/img/icons/arrows/right.png") center center/64px no-repeat;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    -webkit-animation-name: drifting-right;
-    animation-name: drifting-right;
-    -webkit-animation-duration: 2s;
-    animation-duration: 2s;
-    -webkit-animation-iteration-count: infinite;
-    animation-iteration-count: infinite;
-    z-index: 4
+	position:absolute;
+	top:50%;
+	right:-80px;
+	width:100px;
+	height:100px;
+	margin-top:-50px;
+	background:url("/img/icons/arrows/right.png") center center/64px no-repeat;
+	transition:all .1s ease-in-out 0s;
+	animation-name:drifting-right;
+	animation-duration:2s;
+	animation-iteration-count:infinite;
+	z-index:4
 }
 
 .content-btn-left:hover {
@@ -1913,20 +1730,17 @@ a:hover {
 }
 
 .landing-ico-scrolldown {
-    position: fixed;
-    z-index: 3;
-    bottom: 30px;
-    left: 50%;
-    width: 80px;
-    height: 80px;
-    margin: 0 0 0 -40px;
-    -webkit-animation-name: bobbing;
-    animation-name: bobbing;
-    -webkit-animation-duration: 2s;
-    animation-duration: 2s;
-    -webkit-animation-iteration-count: infinite;
-    animation-iteration-count: infinite;
-    background: url("/img/icons/arrows/down.png") center center/50px no-repeat
+	position:fixed;
+	z-index:3;
+	bottom:30px;
+	left:50%;
+	width:80px;
+	height:80px;
+	margin:0 0 0 -40px;
+	animation-name:bobbing;
+	animation-duration:2s;
+	animation-iteration-count:infinite;
+	background:url("/img/icons/arrows/down.png") center center/50px no-repeat
 }
 
 .landing-img-backdrop {
@@ -1986,14 +1800,13 @@ a:hover {
 }
 
 .landing-con-content {
-    overflow: hidden;
-    position: relative;
-    width: 100%;
-    height: 700px;
-    min-height: 600px;
-    max-height: 1080px;
-    background: -o-linear-gradient(225deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%);
-    background: linear-gradient(-135deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%)
+	overflow:hidden;
+	position:relative;
+	width:100%;
+	height:700px;
+	min-height:600px;
+	max-height:1080px;
+	background:linear-gradient(-135deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%)
 }
 
 .landing-con-patreon {
@@ -2038,16 +1851,13 @@ a:hover {
 }
 
 .landing-con-right {
-    position: absolute;
-    right: 0;
-    width: 47%;
-    height: 100%;
-    -webkit-animation-name: fadeInLeft;
-    animation-name: fadeInLeft;
-    -webkit-animation-duration: 1s;
-    animation-duration: 1s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1
+	position:absolute;
+	right:0;
+	width:47%;
+	height:100%;
+	animation-name:fadeInLeft;
+	animation-duration:1s;
+	animation-iteration-count:1
 }
 
 .landing-con-container {
@@ -2056,40 +1866,33 @@ a:hover {
 }
 
 .landing-btn-container {
-    position: relative;
-    width: 100%;
-    height: 44px;
-    margin-top: 30px;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: 1.4s;
-    animation-duration: 1.4s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1
+	position:relative;
+	width:100%;
+	height:44px;
+	margin-top:30px;
+	animation-name:fadeInUp;
+	animation-duration:1.4s;
+	animation-iteration-count:1
 }
 
 .build-btn-button {
-    width: 198px;
-    height: 46px;
-    border-radius: 46px;
-    margin-top: 35px;
-    background: #fff;
-    -webkit-box-shadow: rgba(0,0,0,.05) 0 10px 32px 0;
-    box-shadow: rgba(0,0,0,.05) 0 10px 32px 0;
-    cursor: pointer;
-    padding-left: 4px;
-    padding-right: 4px;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    border: 2px solid #fff
+	width:198px;
+	height:46px;
+	border-radius:46px;
+	margin-top:35px;
+	background:#fff;
+	box-shadow:rgba(0,0,0,.05) 0 10px 32px 0;
+	cursor:pointer;
+	padding-left:4px;
+	padding-right:4px;
+	transition:all .1s ease-in-out 0s;
+	border:2px solid #fff
 }
 
 .build-btn-button:hover {
-    background: #1abc9c;
-    -webkit-box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    border: 2px solid #57e694!important
+	background:#1abc9c;
+	box-shadow:rgba(46,204,113,.4) 0 10px 32px 0;
+	border:2px solid #57e694!important
 }
 
 .build-btn-button:hover .build-tx1-button {
@@ -2145,17 +1948,14 @@ a:hover {
 }
 
 .landing-ico-logo {
-    display: none;
-    width: 100%;
-    height: 64px;
-    margin-bottom: 18px;
-    background: url("/img/icons/menu/logo.png") left center/64px no-repeat;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: 1s;
-    animation-duration: 1s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1
+	display:none;
+	width:100%;
+	height:64px;
+	margin-bottom:18px;
+	background:url("/img/icons/menu/logo.png") left center/64px no-repeat;
+	animation-name:fadeInUp;
+	animation-duration:1s;
+	animation-iteration-count:1
 }
 
 .landing-img-hero {
@@ -2167,36 +1967,30 @@ a:hover {
 }
 
 .landing-tx1-heading {
-    font-family: Roboto-Bold;
-    font-size: 45px;
-    line-height: 64px;
-    position: relative;
-    height: auto;
-    margin-bottom: 16px;
-    color: #fff;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: 1s;
-    animation-duration: 1s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    text-rendering: optimizelegibility;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px
+	font-family:Roboto-Bold;
+	font-size:45px;
+	line-height:64px;
+	position:relative;
+	height:auto;
+	margin-bottom:16px;
+	color:#fff;
+	animation-name:fadeInUp;
+	animation-duration:1s;
+	animation-iteration-count:1;
+	text-rendering:optimizelegibility;
+	text-shadow:rgba(0,0,0,.25) 0 2px 2px
 }
 
 .landing-tx2-heading {
-    font-family: Roboto-Regular;
-    font-size: 16px;
-    line-height: 30px;
-    position: relative;
-    color: #fff;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: 1.2s;
-    animation-duration: 1.2s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px
+	font-family:Roboto-Regular;
+	font-size:16px;
+	line-height:30px;
+	position:relative;
+	color:#fff;
+	animation-name:fadeInUp;
+	animation-duration:1.2s;
+	animation-iteration-count:1;
+	text-shadow:rgba(0,0,0,.25) 0 2px 2px
 }
 
 .landing-con-divider {
@@ -2218,15 +2012,14 @@ a:hover {
 }
 
 .handheld-img-backdrop {
-    background: url("/img/graphics/landing/bg-handheld.jpg") center bottom/cover repeat;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    opacity: .2;
-    -webkit-filter: blur(20px) saturate(200%);
-    filter: blur(20px) saturate(200%);
-    zoom:4}
-
+	background:url("/img/graphics/landing/bg-handheld.jpg") center bottom/cover repeat;
+	width:100%;
+	height:100%;
+	position:absolute;
+	opacity:.2;
+	filter:blur(20px) saturate(200%);
+	zoom:4
+}
 .handheld-img-overlay {
     background: url("/img/graphics/landing/ol-handheld.png") center/cover repeat;
     width: 100%;
@@ -2236,30 +2029,26 @@ a:hover {
 }
 
 .handheld-btn-button {
-    width: 300px;
-    height: 46px;
-    border-radius: 46px;
-    margin-left: -156px;
-    margin-top: 35px;
-    background: #fff;
-    -webkit-box-shadow: rgba(0,0,0,.2) 0 10px 32px 0;
-    box-shadow: rgba(0,0,0,.2) 0 10px 32px 0;
-    cursor: pointer;
-    padding-left: 4px;
-    padding-right: 4px;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    border: 2px solid #fff;
-    position: relative;
-    left: 50%
+	width:300px;
+	height:46px;
+	border-radius:46px;
+	margin-left:-156px;
+	margin-top:35px;
+	background:#fff;
+	box-shadow:rgba(0,0,0,.2) 0 10px 32px 0;
+	cursor:pointer;
+	padding-left:4px;
+	padding-right:4px;
+	transition:all .1s ease-in-out 0s;
+	border:2px solid #fff;
+	position:relative;
+	left:50%
 }
 
 .handheld-btn-button:hover {
-    background: #1abc9c;
-    -webkit-box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    border: 2px solid #57e694!important
+	background:#1abc9c;
+	box-shadow:rgba(46,204,113,.4) 0 10px 32px 0;
+	border:2px solid #57e694!important
 }
 
 .handheld-btn-button:hover .handheld-ico-button {
@@ -2352,28 +2141,24 @@ a:hover {
 }
 
 .github-btn-button {
-    width: 175px;
-    height: 46px;
-    border-radius: 46px;
-    margin-left: 100px;
-    margin-top: 35px;
-    background: #fff;
-    -webkit-box-shadow: rgba(0,0,0,.2) 0 10px 32px 0;
-    box-shadow: rgba(0,0,0,.2) 0 10px 32px 0;
-    cursor: pointer;
-    padding-left: 4px;
-    padding-right: 4px;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    border: 2px solid #fff
+	width:175px;
+	height:46px;
+	border-radius:46px;
+	margin-left:100px;
+	margin-top:35px;
+	background:#fff;
+	box-shadow:rgba(0,0,0,.2) 0 10px 32px 0;
+	cursor:pointer;
+	padding-left:4px;
+	padding-right:4px;
+	transition:all .1s ease-in-out 0s;
+	border:2px solid #fff
 }
 
 .github-btn-button:hover {
-    background: #1abc9c;
-    -webkit-box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    border: 2px solid #57e694!important
+	background:#1abc9c;
+	box-shadow:rgba(46,204,113,.4) 0 10px 32px 0;
+	border:2px solid #57e694!important
 }
 
 .github-btn-button:hover .github-ico-button {
@@ -2409,8 +2194,7 @@ a:hover {
 }
 
 .discord-svg-animate {
-    -webkit-animation: 30s linear 0s infinite alternate none running blobby;
-    animation: 30s linear 0s infinite alternate none running blobby
+	animation:30s linear 0s infinite alternate none running blobby
 }
 
 .discord-con-container {
@@ -2502,28 +2286,24 @@ a:hover {
 }
 
 .discord-btn-button {
-    width: 205px;
-    height: 46px;
-    border-radius: 46px;
-    margin-left: 100px;
-    margin-top: 35px;
-    background: #fff;
-    -webkit-box-shadow: rgba(0,0,0,.2) 0 10px 32px 0;
-    box-shadow: rgba(0,0,0,.2) 0 10px 32px 0;
-    cursor: pointer;
-    padding-left: 4px;
-    padding-right: 4px;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    border: 2px solid #fff
+	width:205px;
+	height:46px;
+	border-radius:46px;
+	margin-left:100px;
+	margin-top:35px;
+	background:#fff;
+	box-shadow:rgba(0,0,0,.2) 0 10px 32px 0;
+	cursor:pointer;
+	padding-left:4px;
+	padding-right:4px;
+	transition:all .1s ease-in-out 0s;
+	border:2px solid #fff
 }
 
 .discord-btn-button:hover {
-    background: #1abc9c;
-    -webkit-box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    border: 2px solid #57e694!important
+	background:#1abc9c;
+	box-shadow:rgba(46,204,113,.4) 0 10px 32px 0;
+	border:2px solid #57e694!important
 }
 
 .discord-btn-button:hover .discord-ico-button {
@@ -2617,33 +2397,28 @@ a:hover {
 }
 
 .patreon-btn-button {
-    width: 188px;
-    height: 46px;
-    background: #ff424d;
-    border-radius: 46px;
-    margin-left: 100px;
-    margin-top: 35px;
-    -webkit-box-shadow: rgba(255,66,77,.5) 0 10px 32px 0;
-    box-shadow: rgba(255,66,77,.5) 0 10px 32px 0;
-    cursor: pointer;
-    padding-left: 4px;
-    padding-right: 4px;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    border: 2px solid #ff2633
+	width:188px;
+	height:46px;
+	background:#ff424d;
+	border-radius:46px;
+	margin-left:100px;
+	margin-top:35px;
+	box-shadow:rgba(255,66,77,.5) 0 10px 32px 0;
+	cursor:pointer;
+	padding-left:4px;
+	padding-right:4px;
+	transition:all .1s ease-in-out 0s;
+	border:2px solid #ff2633
 }
 
 .patreon-btn-button:hover {
-    background: -o-linear-gradient(225deg,rgb(255,145,130) 25%,rgb(255,177,117) 100%);
-    background: linear-gradient(-135deg,rgb(255,145,130) 25%,rgb(255,177,117) 100%)
+	background:linear-gradient(-135deg,rgb(255,145,130) 25%,rgb(255,177,117) 100%)
 }
 
 .patreon-btn-button:hover {
-    background: #1abc9c;
-    -webkit-box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    border: 2px solid #57e694!important
+	background:#1abc9c;
+	box-shadow:rgba(46,204,113,.4) 0 10px 32px 0;
+	border:2px solid #57e694!important
 }
 
 .patreon-btn-button:hover .patreon-ico-patreon {
@@ -2710,17 +2485,14 @@ a:hover {
 }
 
 .search-con-container {
-    position: absolute;
-    top: 50%;
-    width: 100%;
-    height: auto;
-    margin: -25px 0;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: 1s;
-    animation-duration: 1s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1
+	position:absolute;
+	top:50%;
+	width:100%;
+	height:auto;
+	margin:-25px 0;
+	animation-name:fadeInUp;
+	animation-duration:1s;
+	animation-iteration-count:1
 }
 
 .search-con-outer {
@@ -2743,29 +2515,25 @@ a:hover {
 }
 
 .search-inp-search {
-    position: relative;
-    z-index: 1;
-    overflow: hidden;
-    width: 100%;
-    height: 50px;
-    margin: 0 auto;
-    border-radius: 50px;
-    -webkit-box-shadow: rgba(0,0,0,.1) 0 16px 32px 0;
-    box-shadow: rgba(0,0,0,.1) 0 16px 32px 0;
-    border: 2px solid transparent;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	position:relative;
+	z-index:1;
+	overflow:hidden;
+	width:100%;
+	height:50px;
+	margin:0 auto;
+	border-radius:50px;
+	box-shadow:rgba(0,0,0,.1) 0 16px 32px 0;
+	border:2px solid transparent;
+	transition:all .1s ease-in-out 0s
 }
 
 .search-inp-search:hover {
-    cursor: pointer;
-    border-width: 2px;
-    border-style: solid;
-    border-color: #686de0;
-    color: #686de0;
-    -webkit-box-shadow: rgba(0,0,0,.1) 0 16px 32px 0;
-    box-shadow: rgba(0,0,0,.1) 0 16px 32px 0
+	cursor:pointer;
+	border-width:2px;
+	border-style:solid;
+	border-color:#686de0;
+	color:#686de0;
+	box-shadow:rgba(0,0,0,.1) 0 16px 32px 0
 }
 
 .search-inp-search input {
@@ -2788,74 +2556,13 @@ a:hover {
     outline: 0;
     color: #0074e7
 }
-
-.search-inp-search input::-webkit-input-placeholder {
-    -webkit-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    color: inherit
-}
-
-.search-inp-search input::-moz-placeholder {
-    -moz-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    color: inherit
-}
-
-.search-inp-search input:-ms-input-placeholder {
-    -ms-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    color: inherit
-}
-
-.search-inp-search input::-ms-input-placeholder {
-    -ms-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    color: inherit
-}
-
 .search-inp-search input::placeholder {
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    color: inherit
+	transition:all .1s ease-in-out 0s;
+	color:inherit
 }
-
-.search-inp-search:hover input::-webkit-input-placeholder {
-    color: #686de0
-}
-
-.search-inp-search:hover input::-moz-placeholder {
-    color: #686de0
-}
-
-.search-inp-search:hover input:-ms-input-placeholder {
-    color: #686de0
-}
-
-.search-inp-search:hover input::-ms-input-placeholder {
-    color: #686de0
-}
-
 .search-inp-search:hover input::placeholder {
     color: #686de0
 }
-
-.search-inp-search input:focus::-webkit-input-placeholder {
-    color: #686de0
-}
-
-.search-inp-search input:focus::-moz-placeholder {
-    color: #686de0
-}
-
-.search-inp-search input:focus:-ms-input-placeholder {
-    color: #686de0
-}
-
-.search-inp-search input:focus::-ms-input-placeholder {
-    color: #686de0
-}
-
 .search-inp-search input:focus::placeholder {
     color: #686de0
 }
@@ -2885,27 +2592,22 @@ a:hover {
 }
 
 .search-con-author a:hover .search-img-author {
-    -webkit-transform: scale(1.05);
-    -ms-transform: scale(1.05);
-    transform: scale(1.05)
+	transform:scale(1.05)
 }
 
 .search-img-author {
-    width: 32px;
-    height: 32px;
-    position: relative;
-    display: inline-block;
-    border-radius: 100%;
-    top: 14px;
-    margin-left: 4px;
-    margin-right: 4px;
-    -webkit-box-shadow: rgba(0,0,0,.2) 0 0 10px 0;
-    box-shadow: rgba(0,0,0,.2) 0 0 10px 0;
-    border: 2px solid #fff;
-    background: url("/img/users/ani.png") center center/cover no-repeat;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s
+	width:32px;
+	height:32px;
+	position:relative;
+	display:inline-block;
+	border-radius:100%;
+	top:14px;
+	margin-left:4px;
+	margin-right:4px;
+	box-shadow:rgba(0,0,0,.2) 0 0 10px 0;
+	border:2px solid #fff;
+	background:url("/img/users/ani.png") center center/cover no-repeat;
+	transition:all .2s ease-in-out 0s
 }
 
 .search-con-author a {
@@ -2928,22 +2630,17 @@ a:hover {
 }
 
 .video-con-wrapper {
-    position: relative;
-    width: 550px;
-    height: 309px;
-    -webkit-box-shadow: rgba(0,0,0,.2) 20px 20px 64px 0;
-    box-shadow: rgba(0,0,0,.2) 20px 20px 64px 0;
-    border-radius: 16px;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    z-index: 2
+	position:relative;
+	width:550px;
+	height:309px;
+	box-shadow:rgba(0,0,0,.2) 20px 20px 64px 0;
+	border-radius:16px;
+	transition:all .2s ease-in-out 0s;
+	z-index:2
 }
 
 .video-con-wrapper:hover>.video-btn-play {
-    -webkit-transform: scale(1.2);
-    -ms-transform: scale(1.2);
-    transform: scale(1.2)
+	transform:scale(1.2)
 }
 
 .video-con-left {
@@ -2971,126 +2668,104 @@ a:hover {
 }
 
 .video-con-divider {
-    background: -o-linear-gradient(160deg,rgb(78,52,201),rgb(104,109,224));
-    background: linear-gradient(-70deg,rgb(78,52,201),rgb(104,109,224));
-    height: 6px;
-    border-radius: 4px;
-    width: 50px;
-    left: 50%;
-    margin-left: -25px;
-    position: relative;
-    top: 120px
+	background:linear-gradient(-70deg,rgb(78,52,201),rgb(104,109,224));
+	height:6px;
+	border-radius:4px;
+	width:50px;
+	left:50%;
+	margin-left:-25px;
+	position:relative;
+	top:120px
 }
 
 .video-tx1-heading {
-    font-family: Roboto-Bold;
-    font-size: 45px;
-    line-height: 64px;
-    height: 64px;
-    width: 320px;
-    margin-left: -158px;
-    left: 50%;
-    color: #000;
-    text-align: center;
-    position: absolute;
-    top: 44px;
-    z-index: 1;
-    background: -o-linear-gradient(160deg,#4e34c9,#686de0);
-    background: linear-gradient(-70deg,#4e34c9,#686de0);
-    -webkit-text-fill-color: transparent;
-    -webkit-box-decoration-break: clone;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent
+	font-family:Roboto-Bold;
+	font-size:45px;
+	line-height:64px;
+	height:64px;
+	width:320px;
+	margin-left:-158px;
+	left:50%;
+	color:#000;
+	text-align:center;
+	position:absolute;
+	top:44px;
+	z-index:1;
+	background:linear-gradient(-70deg,#4e34c9,#686de0);
+	-webkit-text-fill-color:transparent;
+	-webkit-box-decoration-break:clone;
+	-webkit-background-clip:text;
+	-webkit-text-fill-color:transparent
 }
 
 .video-tx1-description {
-    font-family: Roboto-Bold;
-    font-size: 26px;
-    line-height: 32px;
-    height: auto;
-    color: #000;
-    position: relative;
-    -webkit-animation-duration: 1s;
-    animation-duration: 1s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    padding: 0 30px;
-    -webkit-animation-name: fadeInUp!important;
-    animation-name: fadeInUp!important
+	font-family:Roboto-Bold;
+	font-size:26px;
+	line-height:32px;
+	height:auto;
+	color:#000;
+	position:relative;
+	animation-duration:1s;
+	animation-iteration-count:1;
+	padding:0 30px;
+	animation-name:fadeInUp!important
 }
 
 .video-tx1-description h2 {
-    font-family: Roboto-Bold;
-    font-size: 26px;
-    line-height: 34px;
-    padding: 0 15px;
-    -webkit-animation-duration: 1s;
-    animation-duration: 1s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    -webkit-animation-name: fadeInUp!important;
-    animation-name: fadeInUp!important
+	font-family:Roboto-Bold;
+	font-size:26px;
+	line-height:34px;
+	padding:0 15px;
+	animation-duration:1s;
+	animation-iteration-count:1;
+	animation-name:fadeInUp!important
 }
 
 .video-tx1-description h3 {
-    font-family: Roboto-Regular;
-    font-size: 16px;
-    line-height: 32px;
-    margin-top: 20px;
-    -webkit-animation-duration: 1s;
-    animation-duration: 1s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    -webkit-animation-name: fadeInUp!important;
-    animation-name: fadeInUp!important
+	font-family:Roboto-Regular;
+	font-size:16px;
+	line-height:32px;
+	margin-top:20px;
+	animation-duration:1s;
+	animation-iteration-count:1;
+	animation-name:fadeInUp!important
 }
 
 .video-img-thumbnail {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    border-radius: 16px;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    overflow: hidden
+	position:relative;
+	width:100%;
+	height:100%;
+	border-radius:16px;
+	transition:all .2s ease-in-out 0s;
+	overflow:hidden;
 }
 
 .video-img-overlay {
-    position: absolute;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    overflow: hidden;
-    background: -webkit-gradient(linear,left top,left bottom,color-stop(45%,rgb(0 0 0/0%)),to(rgb(104 109 224/80%)));
-    background: -o-linear-gradient(top,rgb(0 0 0/0%) 45%,rgb(104 109 224/80%) 100%);
-    background: linear-gradient(180deg,rgb(0 0 0/0%) 45%,rgb(104 109 224/80%) 100%)
+	position:absolute;
+	top:0;
+	width:100%;
+	height:100%;
+	transition:all .2s ease-in-out 0s;
+	overflow:hidden;
+	background:linear-gradient(180deg,rgb(0 0 0/0%) 45%,rgb(104 109 224/80%) 100%)
 }
 
 .video-btn-play {
-    position: absolute;
-    z-index: 2;
-    top: 50%;
-    left: 50%;
-    margin: -36px;
-    width: 70px;
-    height: 70px;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    background: url("/img/icons/menu/play.png") center center/cover no-repeat rgba(255,255,255,0.1);
-    -webkit-backdrop-filter: blur(6px);
-    backdrop-filter: blur(6px);
-    border-radius: 100%;
-    pointer-events: none;
-    -webkit-animation-duration: 1s;
-    animation-duration: 1s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    border: solid 1px rgb(255 255 255/20%)
+	position:absolute;
+	z-index:2;
+	top:50%;
+	left:50%;
+	margin:-36px;
+	width:70px;
+	height:70px;
+	transition:all .2s ease-in-out 0s;
+	background:url("/img/icons/menu/play.png") center center/cover no-repeat rgba(255,255,255,0.1);
+	backdrop-filter:blur(6px);
+	border-radius:100%;
+	pointer-events:none;
+	animation-duration:1s;
+	animation-iteration-count:1;
+	border:solid 1px rgb(255 255 255/20%)
 }
 
 .video-ico-service {
@@ -3105,50 +2780,36 @@ a:hover {
 }
 
 .video-con-animate {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    overflow: hidden;
-    z-index: 1;
-    cursor: pointer;
-    -webkit-transform: scale(1.01);
-    -ms-transform: scale(1.01);
-    transform: scale(1.01);
-    border-radius: 16px
+	width:100%;
+	height:100%;
+	position:absolute;
+	overflow:hidden;
+	z-index:1;
+	cursor:pointer;
+	transform:scale(1.01);
+	border-radius:16px;
 }
 
 .video-con-animate::after {
-    content: "";
-    position: absolute;
-    top: -200%;
-    left: -200%;
-    width: 200%;
-    height: 200%;
-    opacity: 0;
-    -webkit-transform: rotate(30deg);
-    -ms-transform: rotate(30deg);
-    transform: rotate(30deg);
-    background: -webkit-gradient(linear,left top,right top,from(rgba(255,255,255,0)),color-stop(77%,rgba(255,255,255,0.14)),color-stop(92%,rgba(255,255,255,0.5)),to(rgba(255,255,255,0)));
-    background: -o-linear-gradient(left,rgba(255,255,255,0) 0%,rgba(255,255,255,0.14) 77%,rgba(255,255,255,0.5) 92%,rgba(255,255,255,0) 100%);
-    background: linear-gradient(to right,rgba(255,255,255,0) 0%,rgba(255,255,255,0.14) 77%,rgba(255,255,255,0.5) 92%,rgba(255,255,255,0) 100%);
-    -webkit-transition: all .7s ease-in-out 0s;
-    -o-transition: all .7s ease-in-out 0s;
-    transition: all .7s ease-in-out 0s
+	content:"";
+	position:absolute;
+	top:-200%;
+	left:-200%;
+	width:200%;
+	height:200%;
+	opacity:0;
+	transform:rotate(30deg);
+	background:linear-gradient(to right,rgba(255,255,255,0) 0%,rgba(255,255,255,0.14) 77%,rgba(255,255,255,0.5) 92%,rgba(255,255,255,0) 100%);
+	transition:all .7s ease-in-out 0s
 }
 
 .video-con-animate:hover::after {
-    opacity: 1;
-    top: -30%;
-    left: -30%;
-    -webkit-transition-property: left,top,opacity;
-    -o-transition-property: left,top,opacity;
-    transition-property: left,top,opacity;
-    -webkit-transition-duration: .7s,.7s,.15s;
-    -o-transition-duration: .7s,.7s,.15s;
-    transition-duration: .7s,.7s,.15s;
-    -webkit-transition-timing-function: ease;
-    -o-transition-timing-function: ease;
-    transition-timing-function: ease
+	opacity:1;
+	top:-30%;
+	left:-30%;
+	transition-property:left,top,opacity;
+	transition-duration:.7s,.7s,.15s;
+	transition-timing-function:ease
 }
 
 .video-con-animate:active::after {
@@ -3156,21 +2817,17 @@ a:hover {
 }
 
 .video-con-animate:hover+.video-img-thumbnail {
-    -webkit-transform: scale(1.01);
-    -ms-transform: scale(1.01);
-    transform: scale(1.01)
+	transform:scale(1.01)
 }
 
 .video-con-dimmer {
-    position: fixed;
-    z-index: 9999;
-    width: 100%;
-    height: 100%;
-    background: rgba(0,0,0,.9);
-    -webkit-backdrop-filter: blur(100px) saturate(800%);
-    backdrop-filter: blur(100px) saturate(800%);
-    display: none;
-    top: 0
+	position:fixed;
+	z-index:9999;
+	width:100%;
+	height:100%;
+	background:rgba(0,0,0,.9);
+	display:none;
+	top:0
 }
 
 .video-ico-viewport {
@@ -3188,24 +2845,20 @@ a:hover {
 }
 
 .video-con-viewport {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    width: 1200px;
-    height: 675px;
-    margin-top: -338px;
-    margin-left: -600px;
-    -webkit-animation-name: zoomIn;
-    animation-name: zoomIn;
-    -webkit-animation-duration: .4s;
-    animation-duration: .4s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1;
-    background: #000;
-    border-radius: 16px;
-    overflow: hidden;
-    -webkit-box-shadow: rgba(0,0,0,.4) 0 0 64px 0;
-    box-shadow: rgba(0,0,0,.4) 0 0 64px 0
+	position:fixed;
+	top:50%;
+	left:50%;
+	width:1200px;
+	height:675px;
+	margin-top:-338px;
+	margin-left:-600px;
+	animation-name:zoomIn;
+	animation-duration:.4s;
+	animation-iteration-count:1;
+	background:#000;
+	border-radius:16px;
+	overflow:hidden;
+	box-shadow:rgba(0,0,0,.4) 0 0 64px 0
 }
 
 .handheld-con-container {
@@ -3286,31 +2939,27 @@ a:hover {
 }
 
 .palette-con-inner-a {
-    height: 100%;
-    border-radius: 12px;
-    background-color: #32353a;
-    background-image: -o-linear-gradient(45deg,rgb(34,36,39) 25%,transparent 0px,transparent 75%,rgb(34,36,39) 0px,rgb(34,36,39)),-o-linear-gradient(45deg,rgb(34,36,39) 25%,transparent 0px,transparent 75%,rgb(34,36,39) 0px,rgb(34,36,39));
-    background-image: linear-gradient(45deg,rgb(34,36,39) 25%,transparent 0px,transparent 75%,rgb(34,36,39) 0px,rgb(34,36,39)),linear-gradient(45deg,rgb(34,36,39) 25%,transparent 0px,transparent 75%,rgb(34,36,39) 0px,rgb(34,36,39));
-    background-size: 30px 30px;
-    background-position: 0 0,45px 45px;
-    -webkit-box-shadow: rgba(0,0,0,.2) 0 10px 16px 0;
-    box-shadow: rgba(0,0,0,.2) 0 10px 16px 0;
-    border: solid 1px rgb(255 255 255/20%)
+	height:100%;
+	border-radius:12px;
+	background-color:#32353a;
+	background-image:linear-gradient(45deg,rgb(34,36,39) 25%,transparent 0px,transparent 75%,rgb(34,36,39) 0px,rgb(34,36,39)),linear-gradient(45deg,rgb(34,36,39) 25%,transparent 0px,transparent 75%,rgb(34,36,39) 0px,rgb(34,36,39));
+	background-size:30px 30px;
+	background-position:0 0,45px 45px;
+	box-shadow:rgba(0,0,0,.2) 0 10px 16px 0;
+	border:solid 1px rgb(255 255 255/20%)
 }
 
 .palette-con-inner-b {
-    margin-left: 20px;
-    margin-right: 20px;
-    height: 100%;
-    border-radius: 12px;
-    background-color: #fff;
-    background-image: -o-linear-gradient(45deg,rgb(228,228,228) 25%,transparent 0px,transparent 75%,rgb(228,228,228) 0px,rgb(228,228,228)),-o-linear-gradient(45deg,rgb(228,228,228) 25%,transparent 0px,transparent 75%,rgb(228,228,228) 0px,rgb(228,228,228));
-    background-image: linear-gradient(45deg,rgb(228,228,228) 25%,transparent 0px,transparent 75%,rgb(228,228,228) 0px,rgb(228,228,228)),linear-gradient(45deg,rgb(228,228,228) 25%,transparent 0px,transparent 75%,rgb(228,228,228) 0px,rgb(228,228,228));
-    background-size: 30px 30px;
-    background-position: 0 0,45px 45px;
-    -webkit-box-shadow: rgba(0,0,0,.2) 0 10px 16px 0;
-    box-shadow: rgba(0,0,0,.2) 0 10px 16px 0;
-    border: solid 1px rgb(255 255 255/20%)
+	margin-left:20px;
+	margin-right:20px;
+	height:100%;
+	border-radius:12px;
+	background-color:#fff;
+	background-image:linear-gradient(45deg,rgb(228,228,228) 25%,transparent 0px,transparent 75%,rgb(228,228,228) 0px,rgb(228,228,228)),linear-gradient(45deg,rgb(228,228,228) 25%,transparent 0px,transparent 75%,rgb(228,228,228) 0px,rgb(228,228,228));
+	background-size:30px 30px;
+	background-position:0 0,45px 45px;
+	box-shadow:rgba(0,0,0,.2) 0 10px 16px 0;
+	border:solid 1px rgb(255 255 255/20%)
 }
 
 .palette-con-text h3 {
@@ -3360,24 +3009,21 @@ a:hover {
 }
 
 .palette-btn-download {
-    width: auto;
-    height: 20px;
-    background: rgba(0,0,0,.3);
-    font-family: Roboto-Regular;
-    font-size: 14px;
-    line-height: 20px;
-    position: relative;
-    color: #fff;
-    padding: 4px 10px;
-    float: right;
-    border-radius: 6px;
-    margin-right: 12px;
-    -webkit-backdrop-filter: blur(5px);
-    backdrop-filter: blur(5px);
-    border: 2px solid rgba(255,255,255,.1);
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	width:auto;
+	height:20px;
+	background:rgba(0,0,0,.3);
+	font-family:Roboto-Regular;
+	font-size:14px;
+	line-height:20px;
+	position:relative;
+	color:#fff;
+	padding:4px 10px;
+	float:right;
+	border-radius:6px;
+	margin-right:12px;
+	backdrop-filter:blur(5px);
+	border:2px solid rgba(255,255,255,.1);
+	transition:all .1s ease-in-out 0s
 }
 
 .palette-btn-download:hover {
@@ -3386,94 +3032,75 @@ a:hover {
 }
 
 .palette-swatch-a {
-    background: #686de0;
-    -webkit-box-shadow: rgba(104,109,224,.5) 0 10px 16px 0;
-    box-shadow: rgba(104,109,224,.5) 0 10px 16px 0
+	background:#686de0;
+	box-shadow:rgba(104,109,224,.5) 0 10px 16px 0
 }
 
 .palette-swatch-b {
-    background: #4e34c9;
-    -webkit-box-shadow: rgba(78,52,201,.5) 0 10px 16px 0;
-    box-shadow: rgba(78,52,201,.5) 0 10px 16px 0
+	background:#4e34c9;
+	box-shadow:rgba(78,52,201,.5) 0 10px 16px 0
 }
 
 .palette-swatch-c {
-    background: #2e1f78;
-    -webkit-box-shadow: rgba(46,31,120,.5) 0 10px 16px 0;
-    box-shadow: rgba(46,31,120,.5) 0 10px 16px 0
+	background:#2e1f78;
+	box-shadow:rgba(46,31,120,.5) 0 10px 16px 0
 }
 
 .palette-swatch-d {
-    background: #212947;
-    -webkit-box-shadow: rgba(33,41,71,.5) 0 10px 16px 0;
-    box-shadow: rgba(33,41,71,.5) 0 10px 16px 0
+	background:#212947;
+	box-shadow:rgba(33,41,71,.5) 0 10px 16px 0
 }
 
 .palette-swatch-e {
-    background: #191f36;
-    -webkit-box-shadow: rgba(25,31,54,.5) 0 10px 16px 0;
-    box-shadow: rgba(25,31,54,.5) 0 10px 16px 0
+	background:#191f36;
+	box-shadow:rgba(25,31,54,.5) 0 10px 16px 0
 }
 
 .palette-swatch-f {
-    background: #111525;
-    -webkit-box-shadow: rgba(17,21,37,.5) 0 10px 16px 0;
-    box-shadow: rgba(17,21,37,.5) 0 10px 16px 0
+	background:#111525;
+	box-shadow:rgba(17,21,37,.5) 0 10px 16px 0
 }
 
 .palette-swatch-g {
-    background: #03a9f4;
-    -webkit-box-shadow: rgba(3,169,244,.5) 0 10px 16px 0;
-    box-shadow: rgba(3,169,244,.5) 0 10px 16px 0
+	background:#03a9f4;
+	box-shadow:rgba(3,169,244,.5) 0 10px 16px 0
 }
 
 .palette-swatch-h {
-    background: #ff3434;
-    -webkit-box-shadow: rgba(255,52,52,.5) 0 10px 16px 0;
-    box-shadow: rgba(255,52,52,.5) 0 10px 16px 0
+	background:#ff3434;
+	box-shadow:rgba(255,52,52,.5) 0 10px 16px 0
 }
 
 .palette-swatch-i {
-    background: #ff9f43;
-    -webkit-box-shadow: rgba(255,159,67,.5) 0 10px 16px 0;
-    box-shadow: rgba(255,159,67,.5) 0 10px 16px 0
+	background:#ff9f43;
+	box-shadow:rgba(255,159,67,.5) 0 10px 16px 0
 }
 
 .user-con-content {
-    position: relative;
-    height: auto;
-    margin-bottom: 40px;
-    border-radius: 16px;
-    -webkit-box-shadow: rgba(0,0,0,.1) 0 10px 32px 0;
-    box-shadow: rgba(0,0,0,.1) 0 10px 32px 0;
-    border: 1px solid rgb(255 255 255/20%);
-    min-height: 175px!important
+	position:relative;
+	height:auto;
+	margin-bottom:40px;
+	border-radius:16px;
+	box-shadow:rgba(0,0,0,.1) 0 10px 32px 0;
+	border:1px solid rgb(255 255 255 / 20%);
+	min-height:175px!important
 }
 
 .user-con-content:hover .user-con-flag {
-    display: block;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    -webkit-animation-name: fadeInLeft;
-    animation-name: fadeInLeft;
-    -webkit-animation-duration: .2s;
-    animation-duration: .2s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1
+	display:block;
+	transition:all .2s ease-in-out 0s;
+	animation-name:fadeInLeft;
+	animation-duration:.2s;
+	animation-iteration-count:1
 }
 
 .user-con-content:hover .user-con-role {
-    opacity: 1;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s
+	opacity:1;
+	transition:all .2s ease-in-out 0s
 }
 
 .user-con-content:hover .user-img-avatar {
-    -webkit-transform: scale(1.05);
-    -ms-transform: scale(1.05);
-    transform: scale(1.05)
+	transform:scale(1.05)
 }
 
 .user-con-wrapper {
@@ -3485,14 +3112,13 @@ a:hover {
 }
 
 .user-con-backdrop {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    z-index: 1;
-    -webkit-backdrop-filter: blur(64px) saturate(200%);
-    backdrop-filter: blur(64px) saturate(200%);
-    border-radius: 16px;
-    overflow: hidden
+	width:100%;
+	height:100%;
+	position:absolute;
+	z-index:1;
+	backdrop-filter:blur(64px) saturate(200%);
+	border-radius:16px;
+	overflow:hidden
 }
 
 .user-img-backdrop {
@@ -3560,99 +3186,82 @@ a:hover {
 }
 
 .user-con-divider {
-    width: 100%;
-    height: 2px;
-    position: relative;
-    border-radius: 4px;
-    margin-bottom: 12px;
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgba(0,0,0,0.05)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgba(0,0,0,0.05));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgba(0,0,0,0.05))
+	width:100%;
+	height:2px;
+	position:relative;
+	border-radius:4px;
+	margin-bottom:12px;
+	background:linear-gradient(to left,rgba(255,255,255,0),rgba(0,0,0,0.05))
 }
 
 .user-con-avatar {
-    position: absolute;
-    /* background: rgb(255 255 255 / 10%); */
-    background: linear-gradient(0deg, rgb(255 255 255 / 10%) 10%, rgba(255, 255, 255, 0) 100%);
-    /* border: solid 1px rgb(255 255 255/20%); */
-    left: 20px;
-    top: 25px;
-    width: 80px;
-    height: 80px;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    border-radius: 16px;
-    -webkit-box-shadow: rgba(0,0,0,.15) 0 8px 8px 0;
-    box-shadow: rgba(0,0,0,.15) 0 8px 8px 0;
-    z-index: 2
+	position:absolute;
+	background:rgb(255 255 255/10%);
+	border:solid 1px rgb(255 255 255/20%);
+	left:20px;
+	top:25px;
+	width:80px;
+	height:80px;
+	transition:all .2s ease-in-out 0s;
+	border-radius:100%;
+	box-shadow:rgba(0,0,0,.15) 0 8px 8px 0;
+	z-index:2;
 }
 
 .user-img-avatar {
-    position: absolute;
-    left: 6px;
-    top: 6px;
-    width: 68px;
-    height: 68px;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    border-radius: 10px;
-    z-index: 2
+	position:absolute;
+	left:6px;
+	top:6px;
+	width:68px;
+	height:68px;
+	transition:all .2s ease-in-out 0s;
+	border-radius:100%;
+	z-index:2;
 }
 
 .user-con-flag {
-    position: absolute;
-    top: 50%;
-    left: -94px;
-    display: none;
-    width: 83px;
-    height: 57px;
-    margin-top: -30.5px;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    -webkit-box-shadow: rgba(0,0,0,.2) 10px 10px 32px 0;
-    box-shadow: rgba(0,0,0,.2) 10px 10px 32px 0;
-    border-radius: 8px;
-    background: rgb(255 255 255/10%);
-    border: solid 1px rgb(255 255 255/20%);
-    -webkit-backdrop-filter: blur(6px);
-    backdrop-filter: blur(6px)
+	position:absolute;
+	top:50%;
+	left:-94px;
+	display:none;
+	width:83px;
+	height:57px;
+	margin-top:-30.5px;
+	transition:all .2s ease-in-out 0s;
+	box-shadow:rgba(0,0,0,.2) 10px 10px 32px 0;
+	border-radius:8px;
+	background:rgb(255 255 255/10%);
+	border:solid 1px rgb(255 255 255/20%);
+	backdrop-filter:blur(6px);
 }
 
 .user-img-flag {
-    position: absolute;
-    bottom: 3px;
-    left: 4px;
-    width: 75px;
-    height: 51px;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    -webkit-box-shadow: rgba(0,0,0,.2) 10px 10px 32px 0;
-    box-shadow: rgba(0,0,0,.2) 10px 10px 32px 0;
-    border-radius: 6px
+	position:absolute;
+	bottom:3px;
+	left:4px;
+	width:75px;
+	height:51px;
+	transition:all .2s ease-in-out 0s;
+	box-shadow:rgba(0,0,0,.2) 10px 10px 32px 0;
+	border-radius:6px;
 }
 
 .user-con-role {
-    font-family: Roboto-Regular;
-    font-size: 12px;
-    font-weight: 100;
-    line-height: 16px;
-    position: relative;
-    top: -2px;
-    float: left;
-    height: 16px;
-    margin-left: 10px;
-    color: #fff;
-    border-radius: 36px;
-    opacity: 0;
-    -webkit-transition: all .2s ease-in-out 0s;
-    -o-transition: all .2s ease-in-out 0s;
-    transition: all .2s ease-in-out 0s;
-    padding: 6px 10px;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px
+	font-family:Roboto-Regular;
+	font-size:12px;
+	font-weight:100;
+	line-height:16px;
+	position:relative;
+	top:-2px;
+	float:left;
+	height:16px;
+	margin-left:10px;
+	color:#fff;
+	border-radius:36px;
+	opacity:0;
+	transition:all .2s ease-in-out 0s;
+	padding:6px 10px;
+	text-shadow:rgba(0,0,0,.25) 0 2px 2px
 }
 
 .user-con-role-gradient {
@@ -3663,23 +3272,19 @@ a:hover {
 }
 
 .user-role-lead {
-    background: #0984e3;
-    -webkit-box-shadow: rgba(9,132,227,.4) 0 8px 16px 0;
-    box-shadow: rgba(9,132,227,.4) 0 8px 16px 0;
-    border: 1px solid #6bbeff
+	background:#0984e3;
+	box-shadow:rgba(9,132,227,.4) 0 8px 16px 0;
+	border:1px solid #6bbeff
 }
 
 .role-lead {
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(9,132,227)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(9,132,227));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(9,132,227))
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(9,132,227))
 }
 
 .user-role-graphics {
-    background: #fd79a8;
-    -webkit-box-shadow: rgba(253,121,168,.4) 0 8px 16px 0;
-    box-shadow: rgba(253,121,168,.4) 0 8px 16px 0;
-    border: 1px solid #ffb6d0
+	background:#fd79a8;
+	box-shadow:rgba(253,121,168,.4) 0 8px 16px 0;
+	border:1px solid #ffb6d0
 }
 
 .role-graphics {
@@ -3689,49 +3294,39 @@ a:hover {
 }
 
 .user-role-manager {
-    background: #fea47f;
-    -webkit-box-shadow: rgba(253,163,127,.4) 0 8px 16px 0;
-    box-shadow: rgba(253,163,127,.4) 0 8px 16px 0;
-    border: 1px solid #ffccb7
+	background:#fea47f;
+	box-shadow:rgba(253,163,127,.4) 0 8px 16px 0;
+	border:1px solid #ffccb7
 }
 
 .role-manager {
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(254,164,127)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(254,164,127));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(254,164,127))
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(254,164,127))
 }
 
 .user-role-web {
-    background: #6c5ce7;
-    -webkit-box-shadow: rgba(108,92,231,.4) 0 5px 16px 0;
-    box-shadow: rgba(108,92,231,.4) 0 5px 16px 0;
-    border: 1px solid #b5aeeb
+	background:#6c5ce7;
+	box-shadow:rgba(108,92,231,.4) 0 5px 16px 0;
+	border:1px solid #b5aeeb
 }
 
 .role-web {
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(108,92,231)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(108,92,231));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(108,92,231))
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(108,92,231))
 }
 
 .user-role-designer {
-    background: #0fbcf9;
-    -webkit-box-shadow: rgba(15,188,249,.4) 0 5px 16px 0;
-    box-shadow: rgba(15,188,249,.4) 0 5px 16px 0;
-    border: 1px solid #6bbeff
+	background:#0fbcf9;
+	box-shadow:rgba(15,188,249,.4) 0 5px 16px 0;
+	border:1px solid #6bbeff
 }
 
 .user-role-ui {
-    background: #cf6a87;
-    -webkit-box-shadow: rgba(207,106,135,.4) 0 8px 16px 0;
-    box-shadow: rgba(207,106,135,.4) 0 8px 16px 0;
-    border: 1px solid #dfb3c0
+	background:#cf6a87;
+	box-shadow:rgba(207,106,135,.4) 0 8px 16px 0;
+	border:1px solid #dfb3c0
 }
 
 .role-ui {
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(207,106,135)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(207,106,135));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(207,106,135))
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(207,106,135))
 }
 
 .user-role-firmware {
@@ -3739,94 +3334,74 @@ a:hover {
 }
 
 .user-role-developer {
-    background: #00b894;
-    -webkit-box-shadow: rgba(0,184,148,.4) 0 8px 16px 0;
-    box-shadow: rgba(0,184,148,.4) 0 8px 16px 0;
-    border: 1px solid #96cdc2
+	background:#00b894;
+	box-shadow:rgba(0,184,148,.4) 0 8px 16px 0;
+	border:1px solid #96cdc2
 }
 
 .role-developer {
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(0,184,148)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(0,184,148));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(0,184,148))
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(0,184,148))
 }
 
 .user-role-contributor {
-    background: #ff8c67;
-    -webkit-box-shadow: rgba(230,131,100,.4) 0 8px 16px 0;
-    box-shadow: rgba(230,131,100,.4) 0 8px 16px 0;
-    border: 1px solid #ffc6b4
+	background:#ff8c67;
+	box-shadow:rgba(230,131,100,.4) 0 8px 16px 0;
+	border:1px solid #ffc6b4
 }
 
 .role-contributor {
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(255,140,103)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(255,140,103));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(255,140,103))
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(255,140,103))
 }
 
 .user-role-editor {
-    background: #4a69bd;
-    -webkit-box-shadow: rgba(74,105,189,.4) 0 8px 16px 0;
-    box-shadow: rgba(74,105,189,.4) 0 8px 16px 0;
-    border: 1px solid #98aad9
+	background:#4a69bd;
+	box-shadow:rgba(74,105,189,.4) 0 8px 16px 0;
+	border:1px solid #98aad9
 }
 
 .role-editor {
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(74,105,189)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(74,105,189));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(74,105,189))
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(74,105,189))
 }
 
 .user-role-wiki {
-    background: #78e08f;
-    -webkit-box-shadow: rgba(120,224,143,.4) 0 5px 16px 0;
-    box-shadow: rgba(120,224,143,.4) 0 5px 16px 0;
-    border: 1px solid #b4e6bf
+	background:#78e08f;
+	box-shadow:rgba(120,224,143,.4) 0 5px 16px 0;
+	border:1px solid #b4e6bf
 }
 
 .role-wiki {
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(120,224,143)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(120,224,143));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(120,224,143))
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(120,224,143))
 }
 
 .user-role-server {
-    background: #38ada9;
-    -webkit-box-shadow: rgba(56,173,169,.4) 0 8px 16px 0;
-    box-shadow: rgba(56,173,169,.4) 0 8px 16px 0;
-    border: 1px solid #97e1df
+	background:#38ada9;
+	box-shadow:rgba(56,173,169,.4) 0 8px 16px 0;
+	border:1px solid #97e1df
 }
 
 .user-role-debugger {
-    background-color: #f1c40f;
-    -webkit-box-shadow: rgba(241,196,15,.4) 0 5px 16px 0;
-    box-shadow: rgba(241,196,15,.4) 0 5px 16px 0
+	background-color:#f1c40f;
+	box-shadow:rgba(241,196,15,.4) 0 5px 16px 0
 }
 
 .user-role-founder {
-    background: #9079ff;
-    -webkit-box-shadow: rgba(76,91,215,.4) 0 8px 16px 0;
-    box-shadow: rgba(76,91,215,.4) 0 8px 16px 0;
-    border: 1px solid #d0c6ff
+	background:#9079ff;
+	box-shadow:rgba(76,91,215,.4) 0 8px 16px 0;
+	border:1px solid #d0c6ff
 }
 
 .role-founder {
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(144,121,255)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(144,121,255));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(144,121,255))
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(144,121,255))
 }
 
 .user-role-former {
-    background: #00cec9;
-    -webkit-box-shadow: rgba(0,206,201,.4) 0 8px 16px 0;
-    box-shadow: rgba(0,206,201,.4) 0 8px 16px 0;
-    border: 1px solid #acdfde
+	background:#00cec9;
+	box-shadow:rgba(0,206,201,.4) 0 8px 16px 0;
+	border:1px solid #acdfde
 }
 
 .role-former {
-    background: -webkit-gradient(linear,right top,left top,from(rgba(255,255,255,0)),to(rgb(0,206,201)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(0,206,201));
-    background: linear-gradient(to left,rgba(255,255,255,0),rgb(0,206,201))
+	background:linear-gradient(to left,rgba(255,255,255,0),rgb(0,206,201))
 }
 
 .user-con-subtitle {
@@ -3859,21 +3434,17 @@ a:hover {
 }
 
 .socialbox-con-button {
-    display: inline-block;
-    margin-right: 2px;
-    border-radius: 12px;
-    padding: 10px 12px;
-    -webkit-box-shadow: rgba(0,0,0,.1) 0 8px 24px 0;
-    box-shadow: rgba(0,0,0,.1) 0 8px 24px 0;
-    margin-bottom: 8px;
-    border: 1px solid rgba(255,255,255,.5);
-    -webkit-backdrop-filter: blur(16px);
-    backdrop-filter: blur(16px);
-    background: rgba(255,255,255,.5);
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    cursor: pointer
+	display:inline-block;
+	margin-right:2px;
+	border-radius:12px;
+	padding:10px 12px;
+	box-shadow:rgba(0,0,0,.1) 0 8px 24px 0;
+	margin-bottom:8px;
+	border:1px solid rgba(255,255,255,.5);
+	backdrop-filter:blur(16px);
+	background:rgba(255,255,255,.5);
+	transition:all .1s ease-in-out 0s;
+	cursor:pointer
 }
 
 .socialbox-con-button:hover {
@@ -3914,20 +3485,16 @@ a:hover {
 }
 
 .specbox-con-part {
-    display: inline-block;
-    margin-right: 2px;
-    border-radius: 12px;
-    padding: 4px 12px 4px 8px;
-    -webkit-box-shadow: rgba(0,0,0,.1) 0 8px 24px 0;
-    box-shadow: rgba(0,0,0,.1) 0 8px 24px 0;
-    margin-bottom: 8px;
-    border: 1px solid rgba(255,255,255,.5);
-    -webkit-backdrop-filter: blur(16px);
-    backdrop-filter: blur(16px);
-    background: rgba(255,255,255,.1);
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	display:inline-block;
+	margin-right:2px;
+	border-radius:12px;
+	padding:4px 12px 4px 8px;
+	box-shadow:rgba(0,0,0,.1) 0 8px 24px 0;
+	margin-bottom:8px;
+	border:1px solid rgba(255,255,255,.5);
+	backdrop-filter:blur(16px);
+	background:rgba(255,255,255,.1);
+	transition:all .1s ease-in-out 0s
 }
 
 .specbox-con-part:hover {
@@ -3980,23 +3547,18 @@ a:hover {
 }
 
 .downloadable-con-inner-a {
-    border-radius: 16px;
-    background: #fff;
-    -webkit-box-shadow: rgba(0,0,0,.1) 0 10px 32px 0;
-    box-shadow: rgba(0,0,0,.1) 0 10px 32px 0;
-    margin: 10px;
-    overflow: hidden;
-    position: relative;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    border: 1px solid rgba(255,255,255,.1)
+	border-radius:16px;
+	background:#fff;
+	box-shadow:rgba(0,0,0,.1) 0 10px 32px 0;
+	margin:10px;
+	overflow:hidden;
+	position:relative;
+	transition:all .1s ease-in-out 0s;
+	border:1px solid rgba(255,255,255,.1)
 }
 
 .downloadable-con-inner-a:hover {
-    -webkit-transform: translate(0px,-10px);
-    -ms-transform: translate(0px,-10px);
-    transform: translate(0px,-10px)
+	transform:translate(0px,-10px)
 }
 
 .downloadable-con-text h3 {
@@ -4079,17 +3641,16 @@ a:hover {
 }
 
 .package-tx2-desc {
-    font-family: Roboto-Regular;
-    font-size: 14px;
-    line-height: 32px;
-    margin-left: 20px;
-    margin-right: 20px;
-    position: relative;
-    width: 170px;
-    -o-text-overflow: ellipsis;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    margin-bottom: 15px
+	font-family:Roboto-Regular;
+	font-size:14px;
+	line-height:32px;
+	margin-left:20px;
+	margin-right:20px;
+	position:relative;
+	width:170px;
+	text-overflow:ellipsis;
+	white-space:nowrap;
+	margin-bottom:15px
 }
 
 .package-tx2-desc span {
@@ -4122,57 +3683,49 @@ a:hover {
 }
 
 .sha2-tx2-desc {
-    min-height: 44px;
-    width: unset;
-    font-family: roboto-regular;
-    font-size: 12px;
-    line-height: 16px;
-    margin-left: 20px;
-    margin-right: 20px;
-    position: relative;
-    -o-text-overflow: ellipsis;
-    text-overflow: ellipsis;
-    overflow-wrap: break-word;
-    border-radius: 8px;
-    padding: 6px 8px;
-    margin-bottom: 17px;
-    color: #1abc9c;
-    background: rgba(26,188,156,.1);
-    border: solid 1px rgb(255 255 255/12%)
+	min-height:44px;
+	width:unset;
+	font-family:roboto-regular;
+	font-size:12px;
+	line-height:16px;
+	margin-left:20px;
+	margin-right:20px;
+	position:relative;
+	text-overflow:ellipsis;
+	overflow-wrap:break-word;
+	border-radius:8px;
+	padding:6px 8px;
+	margin-bottom:17px;
+	color:#1abc9c;
+	background:rgba(26,188,156,.1);
+	border:solid 1px rgb(255 255 255/12%)
 }
 
 .package-con-button-disabled {
-    -webkit-filter: grayscale(100%);
-    filter: grayscale(100%);
-    cursor: not-allowed;
-    background: #525252!important
+	filter:grayscale(100%);
+	cursor:not-allowed;
+	background:#525252!important
 }
 
 .package-con-button {
-    width: 150px;
-    height: 44px;
-    position: relative;
-    margin-top: 40px;
-    margin-left: 20px;
-    border-radius: 12px;
-    bottom: 22px;
-    background: -o-linear-gradient(225deg,rgb(73,164,255) 25%,rgb(0,116,231) 100%);
-    background: linear-gradient(-135deg,rgb(73,164,255) 25%,rgb(0,116,231) 100%);
-    -webkit-box-shadow: rgba(0,116,231,.4) 0 10px 32px 0;
-    box-shadow: rgba(0,116,231,.4) 0 10px 32px 0;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    float: left;
-    border: 2px solid #0080ff!important
+	width:150px;
+	height:44px;
+	position:relative;
+	margin-top:40px;
+	margin-left:20px;
+	border-radius:12px;
+	bottom:22px;
+	background:linear-gradient(-135deg,rgb(73,164,255) 25%,rgb(0,116,231) 100%);
+	box-shadow:rgba(0,116,231,.4) 0 10px 32px 0;
+	transition:all .1s ease-in-out 0s;
+	float:left;
+	border:2px solid #0080ff!important
 }
 
 .package-con-button:hover {
-    background: -o-linear-gradient(225deg,rgb(46,204,113) 25%,rgb(26,188,156) 100%);
-    background: linear-gradient(-135deg,rgb(46,204,113) 25%,rgb(26,188,156) 100%);
-    -webkit-box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    box-shadow: rgba(46,204,113,.4) 0 10px 32px 0;
-    border: 2px solid #57e694!important
+	background:linear-gradient(-135deg,rgb(46,204,113) 25%,rgb(26,188,156) 100%);
+	box-shadow:rgba(46,204,113,.4) 0 10px 32px 0;
+	border:2px solid #57e694!important
 }
 
 .package-tx1-button {
@@ -4192,19 +3745,16 @@ a:hover {
 }
 
 .package-pr {
-    background: #8256d0;
-    border-radius: 12px;
-    padding: 8px 12px;
-    -webkit-box-shadow: rgba(130,86,208,.5) 0 8px 24px 0;
-    box-shadow: rgba(130,86,208,.5) 0 8px 24px 0;
-    margin-right: 5px;
-    float: left;
-    border: 2px solid rgb(255 255 255/20%);
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    margin-bottom: 10px;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px
+	background:#8256d0;
+	border-radius:12px;
+	padding:8px 12px;
+	box-shadow:rgba(130,86,208,.5) 0 8px 24px 0;
+	margin-right:5px;
+	float:left;
+	border:2px solid rgb(255 255 255/20%);
+	transition:all .1s ease-in-out 0s;
+	margin-bottom:10px;
+	text-shadow:rgba(0,0,0,.25) 0 2px 2px
 }
 
 .package-pr:hover {
@@ -4221,20 +3771,17 @@ a:hover {
 }
 
 .package-commit {
-    background: #ff9f43;
-    border-radius: 12px;
-    padding: 8px 12px;
-    -webkit-box-shadow: rgba(255,159,67,.5) 0 8px 24px 0;
-    box-shadow: rgba(255,159,67,.5) 0 8px 24px 0;
-    margin-left: 5px;
-    margin-right: 5px;
-    float: left;
-    border: 2px solid rgb(255 255 255/20%);
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    margin-bottom: 10px;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px
+	background:#ff9f43;
+	border-radius:12px;
+	padding:8px 12px;
+	box-shadow:rgba(255,159,67,.5) 0 8px 24px 0;
+	margin-left:5px;
+	margin-right:5px;
+	float:left;
+	border:2px solid rgb(255 255 255/20%);
+	transition:all .1s ease-in-out 0s;
+	margin-bottom:10px;
+	text-shadow:rgba(0,0,0,.25) 0 2px 2px
 }
 
 .package-commit:hover {
@@ -4252,20 +3799,17 @@ a:hover {
 }
 
 .package-author {
-    background: #1abc9c;
-    border-radius: 12px;
-    padding: 8px 12px;
-    -webkit-box-shadow: rgba(26,188,156,.5) 0 8px 24px 0;
-    box-shadow: rgba(26,188,156,.5) 0 8px 24px 0;
-    margin-left: 5px;
-    margin-right: 25px;
-    float: left;
-    border: 2px solid rgb(255 255 255/20%);
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    margin-bottom: 10px;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px
+	background:#1abc9c;
+	border-radius:12px;
+	padding:8px 12px;
+	box-shadow:rgba(26,188,156,.5) 0 8px 24px 0;
+	margin-left:5px;
+	margin-right:25px;
+	float:left;
+	border:2px solid rgb(255 255 255/20%);
+	transition:all .1s ease-in-out 0s;
+	margin-bottom:10px;
+	text-shadow:rgba(0,0,0,.25) 0 2px 2px
 }
 
 .package-author a {
@@ -4282,18 +3826,17 @@ a:hover {
 }
 
 .version-con-container {
-    background: #fff;
-    -webkit-box-shadow: rgba(0,0,0,.1) 0 10px 32px 0;
-    box-shadow: rgba(0,0,0,.1) 0 10px 32px 0;
-    width: calc(100% - 20px);
-    height: auto;
-    border-radius: 16px;
-    display: inline-block;
-    padding-bottom: 25px;
-    margin-right: 52px;
-    overflow: hidden;
-    position: relative;
-    border: 1px solid rgba(255,255,255,.1)
+	background:#fff;
+	box-shadow:rgba(0,0,0,.1) 0 10px 32px 0;
+	width:calc(100% - 20px);
+	height:auto;
+	border-radius:16px;
+	display:inline-block;
+	padding-bottom:25px;
+	margin-right:52px;
+	overflow:hidden;
+	position:relative;
+	border:1px solid rgba(255,255,255,.1)
 }
 
 .version-ico-package {
@@ -4395,24 +3938,19 @@ a:hover {
 }
 
 .device-con-inner-a {
-    border-radius: 16px;
-    background: #fff;
-    -webkit-box-shadow: rgb(0 0 0/10%) 0 10px 32px 0;
-    box-shadow: rgb(0 0 0/10%) 0 10px 32px 0;
-    margin: 10px;
-    overflow: hidden;
-    position: relative;
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    border: solid 1px rgb(255 255 255/10%);
-    min-height: 640px
+	border-radius:16px;
+	background:#fff;
+	box-shadow:rgb(0 0 0/10%) 0 10px 32px 0;
+	margin:10px;
+	overflow:hidden;
+	position:relative;
+	transition:all .1s ease-in-out 0s;
+	border:solid 1px rgb(255 255 255 / 10%);
+	min-height:640px;
 }
 
 .device-con-inner-a:hover {
-    -webkit-transform: translate(0,-10px);
-    -ms-transform: translate(0,-10px);
-    transform: translate(0,-10px)
+	transform:translate(0,-10px)
 }
 
 .device-con-text h3 {
@@ -4447,17 +3985,15 @@ a:hover {
 }
 
 .device-con-gradient {
-    background: -webkit-gradient(linear,left bottom,left top,from(rgb(104 109 224/15%)),color-stop(70%,rgb(186 190 206/10%)));
-    background: -o-linear-gradient(bottom,rgb(104 109 224/15%) 0%,rgb(186 190 206/10%) 70%);
-    background: linear-gradient(0deg,rgb(104 109 224/15%) 0%,rgb(186 190 206/10%) 70%);
-    height: 360px;
-    margin-top: 10px;
-    position: relative;
-    margin-bottom: 20px;
-    border-radius: 16px;
-    margin-left: 10px;
-    margin-right: 10px;
-    position: relative
+	background:linear-gradient(0deg,rgb(104 109 224 / 15%) 0%,rgb(186 190 206 / 10%) 70%);
+	height:360px;
+	margin-top:10px;
+	position:relative;
+	margin-bottom:20px;
+	border-radius:16px;
+	margin-left:10px;
+	margin-right:10px;
+	position:relative;
 }
 
 .device-tx1-title {
@@ -4480,17 +4016,16 @@ a:hover {
 }
 
 .performance-con-spec {
-    background: #000;
-    position: absolute;
-    width: 38px;
-    height: 38px;
-    z-index: 1;
-    top: 20px;
-    right: 20px;
-    border-radius: 16px;
-    -webkit-box-shadow: rgba(0,0,0,.1) 10px 10px 32px 0;
-    box-shadow: rgba(0,0,0,.1) 10px 10px 32px 0;
-    border: solid 2px rgb(255 255 255/40%)
+	background:#000;
+	position:absolute;
+	width:38px;
+	height:38px;
+	z-index:1;
+	top:20px;
+	right:20px;
+	border-radius:16px;
+	box-shadow:rgba(0,0,0,0.1) 10px 10px 32px 0px;
+	border:solid 2px rgb(255 255 255 / 40%);
 }
 
 .performance-ico-spec {
@@ -4535,17 +4070,15 @@ a:hover {
 }
 
 .gamepad-con-wrapper-gradient {
-    background: -webkit-gradient(linear,right top,left top,from(rgb(6 46 55)),to(rgb(0 0 0/0%)));
-    background: -o-linear-gradient(right,rgb(6 46 55) 0%,rgb(0 0 0/0%) 100%);
-    background: linear-gradient(-90deg,rgb(6 46 55) 0%,rgb(0 0 0/0%) 100%);
-    height: 100%;
-    width: 100px;
-    position: absolute;
-    right: 0;
-    pointer-events: none;
-    z-index: 2;
-    border-radius: 12px;
-    display: none
+	background:linear-gradient(-90deg,rgb(6 46 55) 0%,rgb(0 0 0 / 0%) 100%);
+	height:100%;
+	width:100px;
+	position:absolute;
+	right:0px;
+	pointer-events:none;
+	z-index:2;
+	border-radius:12px;
+	display:none;
 }
 
 .gamepad-con-wrapper::-webkit-scrollbar {
@@ -4553,31 +4086,18 @@ a:hover {
 }
 
 .gamepad-con-item {
-    display: table-cell;
-    min-width: 365px;
-    width: 365px;
-    height: 365px;
-    font-size: 140px;
-    border-radius: 20px;
-    white-space: normal;
-    vertical-align: top;
-    position: relative;
-    background: -webkit-gradient(linear,left bottom,left top,from(rgb(104 109 224/15%)),color-stop(70%,rgb(186 190 206/10%)));
-    background: -o-linear-gradient(bottom,rgb(104 109 224/15%) 0%,rgb(186 190 206/10%) 70%);
-    background: linear-gradient(0deg,rgb(104 109 224/15%) 0%,rgb(186 190 206/10%) 70%);
-    -webkit-box-shadow: 0 10px 16px 0 rgba(0,0,0,.2);
-    box-shadow: 0 10px 6px 0 rgba(0,0,0,.2);
-    -webkit-transition: 1s ease-in-out;
-    -o-transition: .1s ease-in-out;
-    -webkit-transition: .1s ease-in-out;
-    transition: .1s ease-in-out;
-    -webkit-box-shadow: inset 0 0 0 2px rgb(0 0 0/5%);
-    box-shadow: inset 0 0 0 2px rgb(0 0 0/5%)
-}
-
-.gamepad-con-item:hover {
-    -webkit-box-shadow: inset 0 0 0 2px #03a9f4;
-    box-shadow: inset 0 0 0 2px #03a9f4
+	display:table-cell;
+	min-width:365px;
+	width:365px;
+	height:365px;
+	font-size:140px;
+	border-radius:20px;
+	white-space:normal;
+	vertical-align:top;
+	position:relative;
+	background:linear-gradient(0deg,rgb(104 109 224 / 15%) 0%,rgb(186 190 206 / 10%) 70%);
+	-webkit-box-shadow:0 10px 16px 0 rgba(0,0,0,.2);
+	box-shadow:0 10px 6px 0 rgba(0,0,0,.2);
 }
 
 .gamepad-con-tx1 {
@@ -4636,59 +4156,51 @@ a:hover {
 }
 
 .drives-con-outer {
-    height: 60px;
-    position: relative;
-    margin-bottom: 12px
+	height: 60px;
+	position:relative;
+	margin-bottom: 12px;
 }
 
 .drives-con-inner {
-    float: left;
-    width: -webkit-fill-available;
-    font-family: Roboto-Bold;
-    font-size: 12px;
-    line-height: 50px;
-    text-align: left;
-    color: #000;
-    white-space: nowrap;
-    overflow: hidden;
-    -o-text-overflow: ellipsis;
-    text-overflow: ellipsis;
-    -webkit-user-select: all;
-    -moz-user-select: all;
-    user-select: all;
-    margin-right: 12px;
-    padding: 4px 10px;
-    background: -webkit-gradient(linear,left top,right top,from(rgb(104 109 224/10%)),color-stop(70%,rgb(104 109 224/5%)));
-    background: -o-linear-gradient(left,rgb(104 109 224/10%) 0%,rgb(104 109 224/5%) 70%);
-    background: linear-gradient(90deg,rgb(104 109 224/10%) 0%,rgb(104 109 224/5%) 70%);
-    border-radius: 12px;
-    border: solid 1px rgb(255 255 255/10%);
-    display: inline-block
+	float:left;
+	width:-webkit-fill-available;
+	font-family:Roboto-Bold;
+	font-size:12px;
+	line-height:50px;
+	text-align:left;
+	color:#000;
+	white-space:nowrap;
+	overflow:hidden;
+	text-overflow:ellipsis;
+	user-select:all;
+	margin-right:12px;
+	padding:4px 10px;
+	background: linear-gradient(90deg,rgb(104 109 224 / 10%) 0%,rgb(104 109 224 / 5%) 70%);
+	border-radius:12px;
+	border:solid 1px rgb(255 255 255/10%);
+	display: inline-block;
 }
 
 .drives-txt-revisions {
-    position: absolute;
-    background: rgba(0,0,0,.1);
-    height: 20px;
-    line-height: 18px;
-    font-size: 12px;
-    border-radius: 12px;
-    margin-left: 8px;
-    padding: 8px;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    position: relative;
-    background: rgb(0 0 0/5%);
-    top: -1px;
-    border: solid 1px rgb(255 255 255/20%)
+	position:absolute;
+	background:rgba(0,0,0,.1);
+	height:20px;
+	line-height:18px;
+	font-size:12px;
+	border-radius:12px;
+	margin-left:8px;
+	padding:8px 8px;
+	user-select:none;
+	position:relative;
+	background:rgb(0 0 0/5%);
+	top:-1px;
+	border:solid 1px rgb(255 255 255/20%)
 }
 
 .drives-txt-hidden {
-    color: transparent;
-    pointer-events: none;
-    opacity: 0
+	color:transparent;
+	pointer-events: none;
+	opacity: 0;
 }
 
 .drives-ico-bluray {
@@ -4698,25 +4210,21 @@ a:hover {
     position: relative;
     float: left
 }
-
-@media(min-width: 906px) {
-    .drives-con-inner {
-        width:22%
-    }
+@media(min-width:906px) {
+	.drives-con-inner {
+		width:22%
+	}
 }
-
-@media(max-width: 906px) {
-    .drives-txt-hidden {
-        display:none
-    }
-
-    .drives-con-inner:nth-child(2n+1) {
-        background: rgba(0,0,0,.03)
-    }
-
-    .drives-con-outer:nth-child(2n+2) {
-        background: unset
-    }
+@media(max-width:906px) {
+	.drives-txt-hidden {
+		display:none
+	}
+	.drives-con-inner:nth-child(2n+1) {
+		background:rgba(0,0,0,.03)
+	}
+	.drives-con-outer:nth-child(2n+2) {
+		background:unset
+	}
 }
 
 .context-important {
@@ -4731,13 +4239,12 @@ a:hover {
 }
 
 .guide-ico-container {
-    float: left;
-    background: rgb(255 255 255/5%);
-    border-radius: 15px;
-    margin-right: 19px;
-    -webkit-box-shadow: rgb(0 0 0/10%) 0 10px 32px 0;
-    box-shadow: rgb(0 0 0/10%) 0 10px 32px 0;
-    border: solid 1px rgb(255 255 255/10%)
+	float:left;
+	background:rgb(255 255 255/5%);
+	border-radius:15px;
+	margin-right:19px;
+	box-shadow:rgb(0 0 0/10%) 0 10px 32px 0;
+	border:solid 1px rgb(255 255 255/10%)
 }
 
 .guide-ico-content {
@@ -4793,51 +4300,43 @@ a:hover {
 }
 
 .linux-highlight {
-    padding: 2px 8px;
-    background: rgba(240,147,43,.1);
-    border-radius: 24px;
-    color: #f0932b;
-    border: solid 1px rgb(240 147 43/20%);
-    -webkit-user-select: all;
-    -moz-user-select: all;
-    user-select: all;
-    cursor: pointer
+	padding:2px 8px;
+	background:rgba(240,147,43,.1);
+	border-radius:24px;
+	color:#f0932b;
+	border:solid 1px rgb(240 147 43/20%);
+	user-select:all;
+	cursor:pointer
 }
 
 .macos-highlight {
-    padding: 2px 8px;
-    background: rgba(55,43,240,.1);
-    border-radius: 24px;
-    border: solid 1px rgb(55 43 240/20%);
-    color: #372bf0;
-    -webkit-user-select: all;
-    -moz-user-select: all;
-    user-select: all;
-    cursor: pointer
+	padding:2px 8px;
+	background:rgba(55,43,240,.1);
+	border-radius:24px;
+	border:solid 1px rgb(55 43 240/20%);
+	color:#372bf0;
+	user-select:all;
+	cursor:pointer
 }
 
 .bsd-highlight {
-    padding: 2px 8px;
-    background: rgba(255,52,52,.1);
-    border-radius: 24px;
-    color: #ff3434;
-    border: solid 1px rgb(255 52 52/20%);
-    -webkit-user-select: all;
-    -moz-user-select: all;
-    user-select: all;
-    cursor: pointer
+	padding:2px 8px;
+	background:rgba(255,52,52,.1);
+	border-radius:24px;
+	color:#ff3434;
+	border:solid 1px rgb(255 52 52/20%);
+	user-select:all;
+	cursor:pointer
 }
 
 .highlight {
-    color: #0074e7;
-    border-radius: 21px;
-    border: solid 1px rgb(0 116 231/20%);
-    background: rgba(0,128,255,.1);
-    -webkit-user-select: all;
-    -moz-user-select: all;
-    user-select: all;
-    padding: 2px 8px;
-    font-weight: 400
+	color:#0074e7;
+	border-radius:21px;
+	border:solid 1px rgb(0 116 231/20%);
+	background:rgba(0,128,255,.1);
+	user-select:all;
+	padding:2px 8px;
+	font-weight:400
 }
 
 .list-con-container {
@@ -4857,22 +4356,21 @@ a:hover {
 }
 
 .list-tx1-item {
-    font-family: Roboto-Bold;
-    font-size: 26px;
-    line-height: 46px;
-    width: 46px;
-    text-align: center;
-    height: 46px;
-    border-radius: 8px;
-    float: left;
-    top: 50%;
-    margin-top: -23px;
-    margin-left: 10px;
-    position: absolute;
-    background: rgb(255 255 255/5%);
-    -webkit-box-shadow: rgb(0 0 0/10%) 0 10px 32px 0;
-    box-shadow: rgb(0 0 0/10%) 0 10px 32px 0;
-    border: solid 1px rgb(255 255 255/10%)
+	font-family:Roboto-Bold;
+	font-size:26px;
+	line-height:46px;
+	width:46px;
+	text-align:center;
+	height:46px;
+	border-radius:8px;
+	float:left;
+	top:50%;
+	margin-top:-23px;
+	margin-left:10px;
+	position:absolute;
+	background:rgb(255 255 255/5%);
+	box-shadow:rgb(0 0 0/10%) 0 10px 32px 0;
+	border:solid 1px rgb(255 255 255/10%)
 }
 
 .list-tx2-description {
@@ -4894,13 +4392,12 @@ a:hover {
 }
 
 .footer-con-overlay {
-    position: relative;
-    z-index: 1;
-    overflow: hidden;
-    width: 100%;
-    height: auto;
-    background: -o-linear-gradient(225deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%);
-    background: linear-gradient(-135deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%)
+	position:relative;
+	z-index:1;
+	overflow:hidden;
+	width:100%;
+	height:auto;
+	background:linear-gradient(-135deg,rgb(0,42,135) 25%,rgb(147,64,255) 100%)
 }
 
 .footer-con-header {
@@ -5029,22 +4526,18 @@ a:hover {
 }
 
 .footer-ico-container {
-    position: relative;
-    background: rgb(255 255 255/10%);
-    width: 44px;
-    height: 44px;
-    display: inline-block;
-    border: solid 1px rgb(255 255 255/20%);
-    border-radius: 100%;
-    padding: 2px;
-    margin-right: 10px;
-    -webkit-box-shadow: rgba(0,0,0,.2) 6px 6px 10px 0;
-    box-shadow: rgba(0,0,0,.2) 6px 6px 10px 0;
-    -webkit-backdrop-filter: blur(6px);
-    backdrop-filter: blur(6px);
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	position:relative;
+	background:rgb(255 255 255/10%);
+	width:44px;
+	height:44px;
+	display:inline-block;
+	border:solid 1px rgb(255 255 255/20%);
+	border-radius:100%;
+	padding:2px;
+	margin-right:10px;
+	box-shadow:rgba(0,0,0,.2) 6px 6px 10px 0;
+	backdrop-filter:blur(6px);
+	transition:all .1s ease-in-out 0s
 }
 
 .footer-ico-container:hover {
@@ -5063,24 +4556,20 @@ a:hover {
 }
 
 .footer-tx1-developer {
-    font-family: Roboto-Regular;
-    font-weight: 400;
-    font-size: 14px;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px;
-    position: relative;
-    background: rgb(255 255 255/10%);
-    padding: 8px 10px;
-    display: inline-block;
-    border-radius: 38px;
-    border: solid 1px rgb(255 255 255/10%);
-    top: -18px;
-    -webkit-box-shadow: rgba(0,0,0,.2) 6px 6px 10px 0;
-    box-shadow: rgba(0,0,0,.2) 6px 6px 10px 0;
-    -webkit-backdrop-filter: blur(6px);
-    backdrop-filter: blur(6px);
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s
+	font-family:Roboto-Regular;
+	font-weight:400;
+	font-size:14px;
+	text-shadow:rgba(0,0,0,.25) 0 2px 2px;
+	position:relative;
+	background:rgb(255 255 255/10%);
+	padding:8px 10px;
+	display:inline-block;
+	border-radius:38px;
+	border:solid 1px rgb(255 255 255/10%);
+	top:-18px;
+	box-shadow:rgba(0,0,0,.2) 6px 6px 10px 0;
+	backdrop-filter:blur(6px);
+	transition:all .1s ease-in-out 0s
 }
 
 .footer-tx1-developer:hover {
@@ -5175,44 +4664,38 @@ a:hover {
 }
 
 .error-ico-content {
-    position: relative;
-    width: 100%;
-    height: 60px;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s
+	position:relative;
+	width:100%;
+	height:60px;
+	animation-name:fadeInUp;
+	animation-duration:.5s
 }
 
 .error-tx1-content {
-    font-family: Roboto-Light;
-    font-size: 24px;
-    font-weight: 700;
-    line-height: 60px;
-    position: relative;
-    width: 100%;
-    height: 60px;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    text-align: center;
-    color: #fff
+	font-family:Roboto-Light;
+	font-size:24px;
+	font-weight:700;
+	line-height:60px;
+	position:relative;
+	width:100%;
+	height:60px;
+	animation-name:fadeInUp;
+	animation-duration:.5s;
+	text-align:center;
+	color:#fff
 }
 
 .error-tx2-content {
-    font-family: Roboto-Regular;
-    font-size: 16px;
-    line-height: 24px;
-    position: relative;
-    width: 100%;
-    height: 25px;
-    -webkit-animation-name: fadeInUp;
-    animation-name: fadeInUp;
-    -webkit-animation-duration: .5s;
-    animation-duration: .5s;
-    text-align: center;
-    color: #fff
+	font-family:Roboto-Regular;
+	font-size:16px;
+	line-height:24px;
+	position:relative;
+	width:100%;
+	height:25px;
+	animation-name:fadeInUp;
+	animation-duration:.5s;
+	text-align:center;
+	color:#fff
 }
 
 .button-disabled {
@@ -5221,14 +4704,12 @@ a:hover {
 }
 
 .button-enabled {
-    border-radius: 6px;
-    background: -o-linear-gradient(225deg,rgb(73,164,255) 25%,rgb(0,116,231) 100%);
-    background: linear-gradient(-135deg,rgb(73,164,255) 25%,rgb(0,116,231) 100%);
-    cursor: pointer;
-    color: #fff;
-    -webkit-box-shadow: rgba(0,116,231,.2) 10px 10px 32px 0;
-    box-shadow: rgba(0,116,231,.2) 10px 10px 32px 0;
-    border: 2px solid #0080ff!important
+	border-radius:6px;
+	background:linear-gradient(-135deg,rgb(73,164,255) 25%,rgb(0,116,231) 100%);
+	cursor:pointer;
+	color:#fff;
+	box-shadow:rgba(0,116,231,.2) 10px 10px 32px 0;
+	border:2px solid #0080ff!important
 }
 
 .button-enabled:hover {
@@ -5236,8 +4717,7 @@ a:hover {
 }
 
 .disable-transparency {
-    -webkit-backdrop-filter: unset;
-    backdrop-filter: unset
+	backdrop-filter:unset
 }
 
 .disable-pulsate {
@@ -5245,11 +4725,10 @@ a:hover {
 }
 
 .markdown {
-    padding-bottom: 15px;
-    -webkit-box-sizing: border-box!important;
-    box-sizing: border-box!important;
-    margin-bottom: 20px!important;
-    padding-top: 0!important
+	padding-bottom:15px;
+	box-sizing:border-box!important;
+	margin-bottom:20px!important;
+	padding-top:0!important
 }
 
 .markdown a {
@@ -5308,55 +4787,42 @@ a:hover {
 }
 
 .flex-row-wrap {
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
-    -ms-flex-flow: wrap;
-    flex-flow: wrap
+	display:flex;
+	-webkit-box-orient:horizontal;
+	-webkit-box-direction:normal;
+	flex-flow:wrap
 }
 
 .flex-col-wrap {
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-    -ms-flex-flow: column wrap;
-    flex-flow: column wrap
+	display:flex;
+	-webkit-box-orient:vertical;
+	-webkit-box-direction:normal;
+	flex-flow:column wrap
 }
 
 .flexchild-img {
-    -webkit-box-flex: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    margin: 10px
+	flex-grow:1;
+	margin:10px
 }
 
 .img-col-2 {
-    -ms-flex-preferred-size: 50%;
-    flex-basis: 50%
+	flex-basis:50%
 }
 
 .img-col-3 {
-    -ms-flex-preferred-size: 33.33%;
-    flex-basis: 33.33%
+	flex-basis:33.33%
 }
 
 .img-row-2 {
-    -ms-flex-preferred-size: 450px;
-    flex-basis: 450px
+	flex-basis:450px
 }
 
 .img-row-3 {
-    -ms-flex-preferred-size: 250px;
-    flex-basis: 250px
+	flex-basis:250px
 }
 
 .img-row-4 {
-    -ms-flex-preferred-size: 200px;
-    flex-basis: 200px
+	flex-basis:200px
 }
 
 .horizontal-center {
@@ -5381,11 +4847,9 @@ a:hover {
 }
 
 .carousel {
-    position: relative;
-    -webkit-backface-visibility: hidden;
-    backface-visibility: hidden;
-    -webkit-perspective: 1000px;
-    perspective: 1000px
+	position:relative;
+	backface-visibility:hidden;
+	perspective:1000px
 }
 
 .carousel-inner {
@@ -5394,11 +4858,9 @@ a:hover {
 }
 
 .carousel-inner>.item {
-    position: relative;
-    display: none;
-    -webkit-transition: left .6s ease-in-out 0s;
-    -o-transition: left .6s ease-in-out 0s;
-    transition: left .6s ease-in-out 0s
+	position:relative;
+	display:none;
+	transition:left .6s ease-in-out 0s
 }
 
 .carousel-inner>.item>img,.carousel-inner>.item>a>img {
@@ -5411,11 +4873,9 @@ a:hover {
 }
 
 .carousel-inner>.active {
-    left: 0;
-    -webkit-animation-duration: .6s;
-    animation-duration: .6s;
-    -webkit-animation-iteration-count: 1;
-    animation-iteration-count: 1
+	left:0;
+	animation-duration:.6s;
+	animation-iteration-count:1
 }
 
 .carousel-inner>.next,.carousel-inner>.prev {
@@ -5520,13 +4980,11 @@ a:hover {
 }
 
 .carousel-left {
-    -webkit-animation-name: fadeInLeft;
-    animation-name: fadeInLeft
+	animation-name:fadeInLeft
 }
 
 .carousel-right {
-    -webkit-animation-name: fadeInRight;
-    animation-name: fadeInRight
+	animation-name:fadeInRight
 }
 
 #object-particles {
@@ -5547,16 +5005,13 @@ a:hover {
 }
 
 .object-focused {
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
-    border: 2px solid #686de0!important;
-    -webkit-box-shadow: rgba(104,109,224,.2) 0 16px 32px 0!important;
-    box-shadow: rgba(104,109,224,.2) 0 16px 32px 0!important
+	transition:all .1s ease-in-out 0s;
+	border:2px solid #686de0!important;
+	box-shadow:rgba(104,109,224,.2) 0 16px 32px 0!important
 }
 
 .object-hidden {
-    display: none
+	display:none
 }
 
 .object-show {
@@ -5576,9 +5031,7 @@ a:hover {
 }
 
 .pulsate {
-    -webkit-transition: text-shadow 1s linear 0s;
-    -o-transition: text-shadow 1s linear 0s;
-    transition: text-shadow 1s linear 0s
+	transition:text-shadow 1s linear 0s
 }
 
 .pulsate.glow {
@@ -5590,5 +5043,5 @@ a:hover {
 }
 
 #ad_position_box {
-    display: none!important
+	display: none!important
 }

--- a/public_html/lib/css/main.css
+++ b/public_html/lib/css/main.css
@@ -1348,14 +1348,14 @@ a:hover {
 }
 
 .container-con-superblock-emp {
-    border: solid 5px #686de0;
-    background: #686de0;
-    width: 15px;
-    height: 16px;
-    border-radius: 4px;
-    margin-right: 10px;
-    float: left;
-    margin-top: 27px
+	border: solid 5px #686de0;
+  background: #686de0;
+	width:15px;
+	height:16px;
+	border-radius:4px;
+	margin-right:10px;
+	float:left;
+	margin-top:27px;
 }
 
 .container-con-superblock-div {
@@ -1546,14 +1546,14 @@ a:hover {
 }
 
 .spec-emp-block {
-    background: #686de0;
-    width: 52px;
-    height: 52px;
-    border-radius: 16px;
-    margin-right: 10px;
-    float: left;
-    margin-left: 0;
-    border: solid 1px rgb(255 255 255/50%)
+	background:#686de0;
+	width:52px;
+	height:52px;
+	border-radius:16px;
+	margin-right:10px;
+	float:left;
+	margin-left:0px;
+	border:solid 1px rgb(255 255 255 / 50%);
 }
 
 .spec-emp-icon {
@@ -2902,26 +2902,26 @@ a:hover {
 }
 
 .handheld-tx1-title {
-    font-family: roboto-bold;
-    font-size: 24px;
-    line-height: 30px;
-    text-align: center;
-    position: relative;
-    height: 30px;
-    width: 100%;
-    margin-bottom: 10px
+	font-family:Roboto-Bold;
+	font-size:24px;
+	line-height:30px;
+	text-align:center;
+	position:relative;
+	height:30px;
+	width:100%;
+	margin-bottom:10px;
 }
 
 .handheld-tx2-desc {
-    font-family: roboto-regular;
-    font-size: 11px;
-    line-height: 20px;
-    color: #000;
-    text-align: center;
-    position: relative;
-    height: 20px;
-    width: 100%;
-    opacity: .3
+	font-family:Roboto-Regular;
+	font-size:11px;
+	line-height:20px;
+	color:#000;
+	text-align:center;
+	position:relative;
+	height:20px;
+	width:100%;
+	opacity:.3;
 }
 
 .palette-con-container {
@@ -2974,18 +2974,18 @@ a:hover {
 }
 
 .palette-con-text p {
-    font-family: roboto-regular;
-    font-size: 16px;
-    line-height: 18px;
-    color: #fff;
-    height: 18px;
-    padding-left: 20px;
-    padding-top: 5px
+	font-family:Roboto-Regular;
+	font-size:16px;
+	line-height:18px;
+	color:#fff;
+	height:18px;
+	padding-left:20px;
+	padding-top:5px
 }
 
 .palette-con-text-bold {
-    color: rgba(255,255,255,.5);
-    font-family: roboto-bold
+	color:rgba(255,255,255,.5);
+	font-family:Roboto-Bold
 }
 
 .palette-con-image {
@@ -3166,19 +3166,19 @@ a:hover {
 }
 
 .user-tx3-content {
-    font-family: Roboto-Regular;
-    font-size: 14px;
-    line-height: 26px;
-    position: relative;
-    width: 100%;
-    height: auto;
-    text-align: left;
-    color: #000;
-    /* background: rgb(0 0 0 / 5%); */
-    padding: 6px 12px;
-    border-radius: 10px;
-    -webkit-backdrop-filter: blur(32px);
-    /* backdrop-filter: blur(32px); */
+	font-family:Roboto-Regular;
+	font-size:14px;
+	line-height:26px;
+	position:relative;
+	width:100%;
+	height:auto;
+	text-align:left;
+	color: #000;
+	/* background: rgb(0 0 0 / 5%); */
+	padding: 6px 12px;
+	border-radius: 10px;
+	-webkit-backdrop-filter: blur(32px);
+	/* backdrop-filter: blur(32px); */
 }
 
 .user-tx3-content a:hover {
@@ -3196,14 +3196,16 @@ a:hover {
 
 .user-con-avatar {
 	position:absolute;
-	background:rgb(255 255 255/10%);
+	/* background: rgb(255 255 255 / 10%); */
+	background: linear-gradient(0deg, rgb(255 255 255 / 10%) 10%, rgba(255, 255, 255, 0) 100%);
+	/* border: solid 1px rgb(255 255 255/20%); */
 	border:solid 1px rgb(255 255 255/20%);
 	left:20px;
 	top:25px;
 	width:80px;
 	height:80px;
 	transition:all .2s ease-in-out 0s;
-	border-radius:100%;
+	border-radius:16px;
 	box-shadow:rgba(0,0,0,.15) 0 8px 8px 0;
 	z-index:2;
 }
@@ -3215,7 +3217,7 @@ a:hover {
 	width:68px;
 	height:68px;
 	transition:all .2s ease-in-out 0s;
-	border-radius:100%;
+	border-radius:10px;
 	z-index:2;
 }
 
@@ -3286,13 +3288,9 @@ a:hover {
 	box-shadow:rgba(253,121,168,.4) 0 8px 16px 0;
 	border:1px solid #ffb6d0
 }
-
 .role-graphics {
-    background: -webkit-gradient(linear, right top, left top, from(rgba(255, 255, 255, 0)), to(rgb(253 121 168)));
-    background: -o-linear-gradient(right,rgba(255,255,255,0),rgb(9,132,227));
-    background: linear-gradient(to left, rgba(255, 255, 255, 0), rgb(253 121 168));
+	background: linear-gradient(to left, rgba(255, 255, 255, 0), rgb(253 121 168));
 }
-
 .user-role-manager {
 	background:#fea47f;
 	box-shadow:rgba(253,163,127,.4) 0 8px 16px 0;
@@ -3414,10 +3412,10 @@ a:hover {
 }
 
 .user-tx1-subtitle {
-    font-family: roboto-regular;
-    font-size: 14px;
-    line-height: 30px;
-    opacity: .5
+	font-family:Roboto-Regular;
+	font-size:14px;
+	line-height:30px;
+	opacity:.5;
 }
 
 .user-con-socialsheet {
@@ -3573,18 +3571,18 @@ a:hover {
 }
 
 .downloadable-con-text p {
-    font-family: roboto-regular;
-    font-size: 16px;
-    line-height: 18px;
-    color: #fff;
-    height: 18px;
-    padding-left: 20px;
-    padding-top: 5px
+	font-family:Roboto-Regular;
+	font-size:16px;
+	line-height:18px;
+	color:#fff;
+	height:18px;
+	padding-left:20px;
+	padding-top:5px
 }
 
 .downloadable-con-text-bold {
-    color: rgba(255,255,255,.5);
-    font-family: roboto-bold
+	color:rgba(255,255,255,.5);
+	font-family:Roboto-Bold
 }
 
 .downloadable-con-image {
@@ -3618,19 +3616,17 @@ a:hover {
     margin-right: 20px;
     margin-bottom: 20px
 }
-
 .downloadable-tx3-label {
-    background: rgb(255 159 67 / 10%);
-    border: solid 1px rgb(255 159 67 / 60%);
-    border-radius: 6px;
-    padding: 2px 6px;
-    font-family: 'Roboto-Regular';
-    font-size: 14px;
-    top: -4px;
-    position: relative;
-    color: rgb(255 159 67);
+	background: rgb(255 159 67 / 10%);
+	border: solid 1px rgb(255 159 67 / 60%);
+	border-radius: 6px;
+	padding: 2px 6px;
+	font-family:Roboto-Regular;
+	font-size: 14px;
+	top: -4px;
+	position: relative;
+	color: rgb(255 159 67);
 }
-
 .package-tx1-title {
     font-family: Roboto-Bold;
     font-size: 14px;
@@ -3654,15 +3650,15 @@ a:hover {
 }
 
 .package-tx2-desc span {
-    font-size: 14px;
-    font-family: roboto-bold;
-    background: rgba(0,0,0,.05);
-    padding: 6px 12px;
-    border-radius: 12px;
-    position: relative;
-    line-height: 36px;
-    margin-top: 6px;
-    border: solid 1px rgb(255 255 255/10%)
+	font-size:14px;
+	font-family:Roboto-Bold;
+	background:rgba(0,0,0,.05);
+	padding:6px 12px;
+	border-radius:12px;
+	position:relative;
+	line-height:36px;
+	margin-top:6px;
+	border:solid 1px rgb(255 255 255/10%)
 }
 
 .package-tx2-desc-wide {
@@ -3685,7 +3681,7 @@ a:hover {
 .sha2-tx2-desc {
 	min-height:44px;
 	width:unset;
-	font-family:roboto-regular;
+	font-family:Roboto-Regular;
 	font-size:12px;
 	line-height:16px;
 	margin-left:20px;
@@ -3729,12 +3725,12 @@ a:hover {
 }
 
 .package-tx1-button {
-    font-family: roboto-regular;
-    font-size: 18px;
-    line-height: 44px;
-    color: #fff;
-    height: 100%;
-    text-shadow: rgba(0,0,0,.25) 0 2px 2px
+	font-family:Roboto-Regular;
+	font-size:18px;
+	line-height:44px;
+	color:#fff;
+	height:100%;
+	text-shadow:rgba(0,0,0,.25) 0 2px 2px
 }
 
 .package-ico-button {
@@ -3865,19 +3861,19 @@ a:hover {
 }
 
 .version-tx1-package {
-    font-family: roboto-bold;
-    font-size: 24px;
-    line-height: 26px;
-    color: #000;
-    margin-bottom: 4px
+	font-family:Roboto-Bold;
+	font-size:24px;
+	line-height:26px;
+	color:#000;
+	margin-bottom:4px
 }
 
 .version-tx2-package {
-    font-family: roboto-regular;
-    font-size: 16px;
-    line-height: 26px;
-    color: #000;
-    margin-bottom: 16px
+	font-family:Roboto-Regular;
+	font-size:16px;
+	line-height:26px;
+	color:#000;
+	margin-bottom:16px
 }
 
 .version-txt-container {
@@ -3913,7 +3909,7 @@ a:hover {
 }
 
 .device-con-container ul li {
-    font-family: roboto-bold
+	font-family:Roboto-Bold;
 }
 
 .device-con-outer-left {
@@ -3965,18 +3961,18 @@ a:hover {
 }
 
 .device-con-text p {
-    font-family: roboto-regular;
-    font-size: 16px;
-    line-height: 18px;
-    color: #fff;
-    height: 18px;
-    padding-left: 20px;
-    padding-top: 5px
+	font-family:Roboto-Regular;
+	font-size:16px;
+	line-height:18px;
+	color:#fff;
+	height:18px;
+	padding-left:20px;
+	padding-top:5px
 }
 
 .device-con-text-bold {
-    color: rgb(255 255 255/50%);
-    font-family: roboto-bold
+	color:rgb(255 255 255/50%);
+	font-family:Roboto-Bold
 }
 
 .device-con-graphic {
@@ -4573,10 +4569,8 @@ a:hover {
 }
 
 .footer-tx1-developer:hover {
-    background: rgb(255 255 255/20%);
-    -webkit-transition: all .1s ease-in-out 0s;
-    -o-transition: all .1s ease-in-out 0s;
-    transition: all .1s ease-in-out 0s;
+	background:rgb(255 255 255/20%);
+	transition: all .1s ease-in-out 0s;
 }
 
 .footer-con-powered {

--- a/public_html/lib/css/scale.css
+++ b/public_html/lib/css/scale.css
@@ -1,640 +1,621 @@
 @charset "utf-8";
 @media screen and (max-width:480px) {
 	body {
-			-webkit-text-size-adjust:none
+		-webkit-text-size-adjust:none
 	}
 }
 @media screen and (max-width:800px) {
 	.landing-ico-scrolldown {
-			display:none!Important
+		display:none!Important
 	}
 	.menu-con-release {
-			width:100%;
-			border-radius:unset;
-			bottom:0;
-			left:0;
-			text-align:center;
-			background:rgba(17,21,37,.5);
-			height:30px;
-			line-height:30px;
-			padding:unset
+		width:100%;
+		border-radius:unset;
+		bottom:0;
+		left:0;
+		text-align:center;
+		background:rgba(17,21,37,.5);
+		height:30px;
+		line-height:30px;
+		padding:unset
 	}
 	.menu-btn-select {
-			display:none
+		display:none
 	}
 	.menu-con-divider {
-			display:none
+		display:none
 	}
 	.menu-btn-backtotop {
-			display:none!important
+		display:none!important
 	}
 	.menu-btn-settings {
-			display:none
+		display:none
 	}
 	.menu-con-outer {
-			margin:auto 30px
+		margin:auto 30px
 	}
 	.content-con-inside {
-			margin-right:20px;
-			margin-left:20px
+		margin-right:20px;
+		margin-left:20px
 	}
 	.generic-tx1-button {
-			font-size:12px
+		font-size:12px
 	}
 	.spec-con-min {
-			width:100%;
-			float:unset
+		width:100%;
+		float:unset
 	}
 	.spec-con-max {
-			width:100%;
-			float:unset
+		width:100%;
+		float:unset
 	}
 	.req-item {
-			margin-bottom:30px
+		margin-bottom:30px
 	}
 	.landing-con-panel {
-			height:100px
+		height:100px
 	}
 	.landing-tx1-panel {
-			font-size:20px;
-			letter-spacing:8px;
-			text-indent:8px;
-			line-height:20px;
-			top:40px
+		font-size:20px;
+		letter-spacing:8px;
+		text-indent:8px;
+		line-height:20px;
+		top:40px
 	}
 	.footer-con-inner {
-			margin-right:20px;
-			margin-left:20px
+		margin-right:20px;
+		margin-left:20px
 	}
 	.footer-con-bound {
-			left:0
+		left:0
 	}
 	.footer-ico-logo {
-			display:none
+		display:none
 	}
 	.footer-con-side {
-			width:100%;
-			top:30px
+		width:100%;
+		top:30px
 	}
 	.footer-tx1-webmaster {
-			left:0
+		left:0
 	}
 	.splitter-con-container {
-			display:unset
+		display:unset
 	}
 	.splitter-txt-wrapper {
-			width:100%
+		width:100%
 	}
 	.splitter-con-right {
-			margin-top:20px;
-			margin-bottom:30px;
-			display:unset;
-			width:100%
+		margin-top:20px;
+		margin-bottom:30px;
+		display:unset;
+		width:100%
 	}
 	.splitter-con-left {
-			margin:unset;
-			display:unset;
-			width:100%
+		margin:unset;
+		display:unset;
+		width:100%
 	}
 	.splitter-img-wrapper {
-			width:100%;
-			height:300px
+		width:100%;
+		height:300px
 	}
 	.splitter-img-container {
-			display:none
+		display:none
 	}
 	.mini-menu-con-container {
-			width:unset;
-			margin-left:20px;
-			margin-right:20px;
-			left: unset
+		width:unset;
+		margin-left:20px;
+		margin-right:20px;
+		left: unset
 	}
 	.highlight {
-			/* white-space:unset;*/
+		/* white-space:unset;*/
 		/* border:unset;*/
 		/* background:unset;*/
 	}
 	.windows-highlight {
-			white-space:unset;
-			border:unset;
-			background: unset
+		white-space:unset;
+		border:unset;
+		background: unset
 	}
 	.linux-highlight {
-			white-space:unset;
-			/* border:unset;*/
+		white-space:unset;
+		/* border:unset;*/
 		/* background:unset;*/
 	}
 	.bsd-highlight {
-			/* white-space:unset;*/
+		/* white-space:unset;*/
 		/* border:unset;*/
 		/* background:unset;*/
 	}
 }
 @media screen and (max-width:1260px) {
 	.page-con-container {
-			margin:auto 20px
+		margin:auto 20px
 	}
 }
 @media screen and (max-width:800px) {
 	.footer-con-sources {
-			display:none
+		display:none
 	}
 }
 @media screen and (max-width:800px) {
 	.video-con-left {
-			width:100%
+		width:100%
 	}
 	.video-con-right {
-			width:100%;
-			margin-top:30px
+		width:100%;
+		margin-top:30px
 	}
 	.video-con-container {
-			top:unset;
-			margin-top:unset;
-			height:100%
+		top:unset;
+		margin-top:unset;
+		height:100%
 	}
 	.video-con-wrapper {
-			margin-top:18px!important;
-			margin-left:unset!important
+		margin-top:18px!important;
+		margin-left:unset!important
 	}
 	.video-tx1-heading {
-			display:none
+		display:none
 	}
 	.video-tx1-description {
-			top:unset!important;
-			margin-top:unset!important;
-			padding:0!important
+		top:unset!important;
+		margin-top:unset!important;
+		padding:0!important
 	}
 	.video-tx1-description h2 {
-			font-size:32px;
-			line-height:46px;
-			padding:0
+		font-size:32px;
+		line-height:46px;
+		padding:0
 	}
 	.content-btn-left {
-			width:60px;
-			height:60px;
-			top:190px
+		width:60px;
+		height:60px;
+		top:190px
 	}
 	.content-btn-right {
-			width:60px;
-			height:60px;
-			top:190px
+		width:60px;
+		height:60px;
+		top:190px
 	}
 	.video-emp-block {
-			display:none
+		display:none
 	}
 	.video-con-divider {
-			display:none
+		display:none
 	}
 	.palette-con-container {
-			height:auto!important
+		height:auto!important
 	}
 	.palette-con-outer {
-			float:unset!important;
-			width:100%!important;
-			margin-bottom:20px;
-			height:170px!important
+		float:unset!important;
+		width:100%!important;
+		margin-bottom:20px;
+		height:170px!important
 	}
 	.palette-con-inner-b {
-			margin-left:0!important;
-			margin-right:0!important
+		margin-left:0!important;
+		margin-right:0!important
 	}
 	.generic-btn-button {
-			width:unset;
-			padding-left:0;
-			padding-right:0;
-			display:block;
-			margin-right:unset
+		width:unset;
+		padding-left:0;
+		padding-right:0;
+		display:block;
+		margin-right:unset
+	}
+	.alipay-con-alipay {
+		width:100%;
+		left:unset;
+		margin-left:unset;
+		background:unset
 	}
 }
 @media screen and (max-width:800px) {
 	.mobile-menu-btn-open {
-			display:block;
-			height:70px;
-			background-size:20px
+		display:block;
+		height:70px;
+		background-size:20px
 	}
 }
 @media screen and (max-width:800px) {
 	.footer-tx1-developer {
-			display:none
+		display:none
 	}
 }
 @media screen and (max-width:1260px) {
 	.override-show {
-			display:block
+		display:block
 	}
 }
 @media screen and (max-width:1260px) {
 	.override-hide {
-			display:none
+		display:none
 	}
 }
 @media screen and (max-width:1260px) {
 	.override-promote {
-			left:50%!important;
-			display:block!important;
-			width:372px!important;
-			margin-left:-186px!important
+		left:50%!important;
+		display:block!important;
+		width:372px!important;
+		margin-left:-186px!important
 	}
 }
 @media screen and (max-height:780px) {
 	.video-con-viewport {
-			-webkit-transform:scale(.7);
-			    -ms-transform:scale(.7);
-			        transform:scale(.7)
+		transform:scale(.7)
 	}
 }
 @media screen and (max-height:600px) {
 	.video-con-viewport {
-			-webkit-transform:scale(.6);
-			    -ms-transform:scale(.6);
-			        transform:scale(.6)
+		transform:scale(.6)
 	}
 }
 @media screen and (max-height:400px) {
 	.video-con-viewport {
-			-webkit-transform:scale(.5);
-			    -ms-transform:scale(.5);
-			        transform:scale(.5)
+		transform:scale(.5)
 	}
 }
 @media screen and (max-width:1240px) {
 	.video-con-viewport {
-			-webkit-transform:scale(.8);
-			    -ms-transform:scale(.8);
-			        transform:scale(.8)
+		transform:scale(.8)
 	}
 }
 @media screen and (max-width:1010px) {
 	.video-con-viewport {
-			-webkit-transform:scale(.6);
-			    -ms-transform:scale(.6);
-			        transform:scale(.6)
+		transform:scale(.6)
 	}
 }
 @media screen and (max-width:800px) {
 	.video-con-viewport {
-			-webkit-transform:scale(.25);
-			    -ms-transform:scale(.25);
-			        transform:scale(.25)
+		transform:scale(.25)
 	}
 }
 @media screen and (max-width:750px) {
 	.download-define-build {
-			display:none
+		display:none
 	}
 }
 @media screen and (max-width:800px) {
 	.landing-con-main {
-			height:90%
+		height:90%
 	}
 	.landing-ico-logo {
-			display:block!important
+		display:block!important
 	}
 	.landing-tx1-heading {
-			font-size:32px;
-			line-height:46px
+		font-size:32px;
+		line-height:46px
 	}
 	.landing-btn-download {
-			margin-left:26px;
-			bottom:-15px;
-			-webkit-transform:scale(1.4);
-			    -ms-transform:scale(1.4);
-			        transform:scale(1.4)
+		margin-left:26px;
+		bottom:-15px;
+		transform:scale(1.4)
 	}
 	.landing-tx1-download {
-			display:none
+		display:none
 	}
 	.wavebar-con-container-master {
-			height:90%
+		height:90%
 	}
 	.content-expand {
-			width:100%
+		width:100%
 	}
 	.content-remove {
-			display:none
+		display:none
 	}
 	.img-row-3 {
-			-ms-flex-preferred-size:450px;
-			    flex-basis:450px
+		flex-basis:450px
 	}
 	.img-row-4 {
-			-ms-flex-preferred-size:250px;
-			    flex-basis:250px
+		flex-basis:250px
 	}
 	.img-col-2,.img-col-3 {
-			-ms-flex-preferred-size:100%;
-			    flex-basis:100%
+		flex-basis:100%
 	}
 }
 @media screen and (max-width:1395px) {
 	.user-con-flag {
-			display:none!important
+		display:none!important
 	}
 }
 @media screen and (max-width:1090px) {
 	.video-ico-service {
-			display:none!important
+		display:none!important
 	}
 }
 @media screen and (max-width:800px) {
 	#object-particles {
-			display:none
+		display:none
 	}
 	.revision-tx1-container {
-			display:none
+		display:none
 	}
 	.menu-con-container {
-			height:70px
+		height:70px
 	}
 	.menu-btn-darkmode {
-			height:100px
+		height:100px
 	}
 	.menu-ico-logo {
-			height:70px;
-			width:140px;
-			background:url("/img/icons/menu/logo-wide-light.png") center center/36px no-repeat;
-			background-size:contain
+		height:70px;
+		width:140px;
+		background:url("/img/icons/menu/logo-wide-light.png") center center/36px no-repeat;
+		background-size:contain
 	}
 	.support-ico-menu {
-			height:100px
+		height:100px
 	}
 	.support-con-outer {
-			display:none;
-			top:100px;
-			left:-128px
+		display:none;
+		top:100px;
+		left:-128px
 	}
 	.content-btn-left {
-			left:6px;
-			background:rgba(255,255,255,.8) url(/img/icons/arrows/left.png) no-repeat center!important;
-			background-size:32px!important;
-			border-radius:12px;
-			backdrop-filter:blur(6px);
-			-webkit-backdrop-filter:blur(6px);
-			-webkit-box-shadow:rgb(0 0 0/20%) 0 6px 10px 0;
-			        box-shadow:rgb(0 0 0/20%) 0 6px 10px 0
+		left:6px;
+		background:rgba(255,255,255,.8) url(/img/icons/arrows/left.png) no-repeat center!important;
+		background-size:32px!important;
+		border-radius:12px;
+		backdrop-filter:blur(6px);
+		-webkit-backdrop-filter:blur(6px);
+		box-shadow:rgb(0 0 0/20%) 0 6px 10px 0
 	}
 	.content-btn-right {
-			right:14px;
-			background:rgba(255,255,255,.8) url(/img/icons/arrows/right.png) no-repeat center!important;
-			background-size:32px!important;
-			border-radius:12px;
-			backdrop-filter:blur(6px);
-			-webkit-backdrop-filter:blur(6px);
-			-webkit-box-shadow:rgb(0 0 0/20%) 0 6px 10px 0;
-			        box-shadow:rgb(0 0 0/20%) 0 6px 10px 0
+		right:14px;
+		background:rgba(255,255,255,.8) url(/img/icons/arrows/right.png) no-repeat center!important;
+		background-size:32px!important;
+		border-radius:12px;
+		backdrop-filter:blur(6px);
+		-webkit-backdrop-filter:blur(6px);
+		box-shadow:rgb(0 0 0/20%) 0 6px 10px 0
 	}
 	.content-btn-left:hover {
-			left:6px;
-			background:rgba(255,255,255,.8) url(/img/icons/arrows/left-a.png) no-repeat center!important;
-			background-size:32px!important;
-			border-radius:12px;
-			backdrop-filter:blur(6px);
-			-webkit-backdrop-filter:blur(6px)
+		left:6px;
+		background:rgba(255,255,255,.8) url(/img/icons/arrows/left-a.png) no-repeat center!important;
+		background-size:32px!important;
+		border-radius:12px;
+		backdrop-filter:blur(6px);
+		-webkit-backdrop-filter:blur(6px)
 	}
 	.content-btn-right:hover {
-			right:14px;
-			background:rgba(255,255,255,.8) url(/img/icons/arrows/right-a.png) no-repeat center!important;
-			background-size:32px!important;
-			border-radius:12px;
-			backdrop-filter:blur(6px);
-			-webkit-backdrop-filter:blur(6px)
+		right:14px;
+		background:rgba(255,255,255,.8) url(/img/icons/arrows/right-a.png) no-repeat center!important;
+		background-size:32px!important;
+		border-radius:12px;
+		backdrop-filter:blur(6px);
+		-webkit-backdrop-filter:blur(6px)
 	}
 	.video-con-wrapper {
-			width:100%;
-			left:unset;
-			margin-top:-304px;
-			margin-left:unset
+		width:100%;
+		left:unset;
+		margin-top:-304px;
+		margin-left:unset
 	}
 	.dm-gradient {
-			background:url(/img/graphics/landing/gradient-dark.png) no-repeat center bottom;
-			background-size:contain
+		background:url(/img/graphics/landing/gradient-dark.png) no-repeat center bottom;
+		background-size:contain
 	}
 	.landing-con-search {
-			display:none
+		display:none
 	}
 	.landing-tx2-heading {
-			font-size:16px;
-			line-height:30px
+		font-size:16px;
+		line-height:30px
 	}
 	.github-con-logo {
-			display:none!important
+		display:none!important
 	}
 	.github-con-mantra {
-			width:100%!important
+		width:100%!important
 	}
 	.github-tx1-mantra {
-			padding-left:0!important;
-			font-size:32px;
-			line-height:46px
+		padding-left:0!important;
+		font-size:32px;
+		line-height:46px
 	}
 	.github-tx2-mantra {
-			padding-left:0!important;
-			font-size:16px;
-			line-height:30px
+		padding-left:0!important;
+		font-size:16px;
+		line-height:30px
 	}
 	.github-btn-button {
-			margin-left:0!important;
-			position:absolute!important
+		margin-left:0!important;
+		position:absolute!important
 	}
 	.patreon-con-logo {
-			display:none!important
+		display:none!important
 	}
 	.patreon-con-mantra {
-			width:100%!important
+		width:100%!important
 	}
 	.patreon-tx1-mantra {
-			padding-left:0!important;
-			font-size:32px;
-			line-height:46px
+		padding-left:0!important;
+		font-size:32px;
+		line-height:46px
 	}
 	.patreon-tx2-mantra {
-			padding-left:0!important;
-			font-size:16px;
-			line-height:30px
+		padding-left:0!important;
+		font-size:16px;
+		line-height:30px
 	}
 	.patreon-btn-button {
-			margin-left:0!important;
-			position:absolute!important
+		margin-left:0!important;
+		position:absolute!important
 	}
 	.discord-con-logo {
-			display:none!important
+		display:none!important
 	}
 	.discord-con-mantra {
-			width:100%!important
+		width:100%!important
 	}
 	.discord-tx1-mantra {
-			padding-left:0!important;
-			font-size:32px;
-			line-height:46px
+		padding-left:0!important;
+		font-size:32px;
+		line-height:46px
 	}
 	.discord-tx2-mantra {
-			padding-left:0!important;
-			font-size:16px;
-			line-height:30px
+		padding-left:0!important;
+		font-size:16px;
+		line-height:30px
 	}
 	.discord-btn-button {
-			margin-left:0!important;
-			position:absolute!important
+		margin-left:0!important;
+		position:absolute!important
 	}
 	.footer-tx2-developer {
-			width:100%;
-			text-align:center;
-			font-size:20px
+		width:100%;
+		text-align:center;
+		font-size:20px
 	}
 	.user-img-avatar {
-			background:url(/img/users/avatars/nekotekina.png) no-repeat center;
-			background-size:cover;
-			top:0;
-			margin-top:6px;
+		background:url(/img/users/avatars/nekotekina.png) no-repeat center;
+		background-size:cover;
+		top:0;
+		margin-top:6px;
 	}
 	.user-con-wrapper {
-			padding-top:20px;
-			padding-bottom:20px;
-			padding-left:20px;
-			padding-right:20px;
-			margin-top:100px;
+		padding-top:20px;
+		padding-bottom:20px;
+		padding-left:20px;
+		padding-right:20px;
+		margin-top:100px;
 	}
 	.user-con-role {
-			display:none
+		display:none
 	}
 	.sidebar-btn-open {
-			display:none
+		display:none
 	}
 	.landing-con-video {
-			height:680px
+		height:680px
 	}
 	.landing-con-discord {
-			height:500px
+		height:500px
 	}
 	.discord-right-logo {
-			width:100%;
-			left:25%
+		width:100%;
+		left:25%
 	}
 	.discord-left-logo {
-			display:none
+		display:none
 	}
 	.landing-con-contribute {
-			height:500px
+		height:500px
 	}
 	.landing-con-patreon {
-			height:500px
+		height:500px
 	}
 }
 @media screen and (max-width:1492px) {
 	.menu-tx1-settings span {
-			display:none
+		display:none
 	}
 }
 @media screen and (max-width:1325px) {
 	.support-con-menu {
-			display:none
+		display:none
 	}
 }
 @media screen and (max-width:800px) {
 	.settings-menu-con-outer {
-			display:none!important
+		display:none!important
 	}
 }
 @media screen and (max-width:800px) {
 	.menu-tx1-settings {
-			display:block;
-			line-height:100px!important
+		display:block;
+		line-height:100px!important
 	}
 }
 @media screen and (max-width:800px) {
 	.downloadable-con-container {
-			height:auto!important;
-			margin-left:unset
+		height:auto!important;
+		margin-left:unset
 	}
 	.downloadable-con-outer {
-			float:unset!important;
-			width:100%!important;
-			margin-bottom:20px
+		float:unset!important;
+		width:100%!important;
+		margin-bottom:20px
 	}
 	.downloadable-con-inner-b {
-			margin-left:0!important;
-			margin-right:0!important
+		margin-left:0!important;
+		margin-right:0!important
 	}
 	.downloadable-con-inner-a {
-			margin:0
+		margin:0
 	}
 	.version-con-container {
-			margin-right:0;
-			width:100%
+		margin-right:0;
+		width:100%
 	}
 	.package-pr {
-			margin-left:0;
-			margin-right:8px
+		margin-left:0;
+		margin-right:8px
 	}
 	.package-commit {
-			margin-left:0;
-			margin-right:8px
+		margin-left:0;
+		margin-right:8px
 	}
 	.package-author {
-			margin-left:0;
-			margin-right:8px
+		margin-left:0;
+		margin-right:8px
 	}
 }
 @media screen and (max-width:445px) {
 	.downloadable-con-graphic {
-			display:none!important
+		display:none!important
 	}
 }
 @media screen and (max-width:600px) {
 	.version-img-container {
-			display:none!important
+		display:none!important
 	}
 }
 @media screen and (max-width:800px) {
 	.divTableCell,.divTableHead {
-			white-space:nowrap;
-			overflow:hidden;
-			-o-text-overflow:ellipsis;
-			   text-overflow:ellipsis
+		white-space:nowrap;
+		overflow:hidden;
+		text-overflow:ellipsis
 	}
 }
 @media screen and (max-width:1660px) {
 	.sidebar span {
-			display:none;
+		display:none;
 	}
 	.sidebarsettings span {
-			display:none;
+		display:none;
 	}
 }
 @media screen and (max-width:830px) {
 		.landing-con-handheld {
-			display:none;
+		display:none;
 	}
 }
-@media screen and (max-width:1630px) {
-	.sidebar-btn-tx1-tooltip {
-			display:none;
+@media screen and (max-width:800px) {
+	.device-con-container {
+		height:auto!important;
+		margin-left:unset
 	}
-	@media screen and (max-width:800px) {
-		.device-con-container {
-				height:auto!important;
-				margin-left:unset
-		}
-		.device-con-outer {
-				float:unset!important;
-				width:100%!important;
-				margin-bottom:20px
-		}
-			.device-con-outer-left,.device-con-outer-right {
-				float:unset!important;
-				width:100%!important;
-				margin-bottom:20px
-		}
-		 .device-con-inner-b {
-				margin-left:0!important;
-				margin-right:0!important
-		}
-		.device-con-inner-a {
-				margin:0
-		}
-			.window-con-emu {
-					display: none;
-		}
+	.device-con-outer {
+		float:unset!important;
+		width:100%!important;
+		margin-bottom:20px
+	}
+		.device-con-outer-left,.device-con-outer-right {
+		float:unset!important;
+		width:100%!important;
+		margin-bottom:20px
+	}
+	 .device-con-inner-b {
+		margin-left:0!important;
+		margin-right:0!important
+	}
+	.device-con-inner-a {
+		margin:0
+	}
+		.window-con-emu {
+			display: none;
 	}
 }


### PR DESCRIPTION
A broken formatting tool added a bunch of deprecated CSS properties, undoes those changes while preserving any actual CSS changes. Gets rid of all CSS warnings introduced by that commit.