### PR TITLE
download/quickstart: Update OS requirements, add macOS 12/11 legacy builds, fix syntax error

### DIFF
--- a/public_html/download.php
+++ b/public_html/download.php
@@ -147,7 +147,7 @@ if (@include_once("lib/compat/objects/Build.php"))
 					</div>
 					<div class='container-tx2-block darkmode-txt'>
 						<p class="download-desc">
-							 For FreeBSD users, RPCS3 supports active FreeBSD 13 and FreeBSD 12 versions.
+							 For FreeBSD users, RPCS3 supports active FreeBSD 14 and FreeBSD 13 versions.
 							<br>
 							<b>Install as a package </b><span class="highlight darkmode-highlight">pkg install rpcs3</span>
 							<br>

--- a/public_html/download.php
+++ b/public_html/download.php
@@ -102,7 +102,7 @@ if (@include_once("lib/compat/objects/Build.php"))
 							 <br>
 							 Once uncompressed, place your RPCS3 folder in a convenient location to start, such as: <span class="highlight darkmode-highlight">C:\Users\Kratos\Desktop\RPCS3\rpcs3.exe</span>
 							 <br>
-							 <b>Download dependencies </b><span class="highlight darkmode-highlight"><a href="https://aka.ms/vs/17/release/vc_redist.x64.exe" target="_blank">Microsoft Visual C++ 2019 Redistributable</a></span>
+							 <b>Download dependencies </b><span class="highlight darkmode-highlight"><a href="https://aka.ms/vs/17/release/vc_redist.x64.exe" target="_blank">Microsoft Visual C++ 2015-2022 Redistributable</a></span>
 						</p>
 					</div>
 				</div>

--- a/public_html/download.php
+++ b/public_html/download.php
@@ -91,6 +91,28 @@ if (@include_once("lib/compat/objects/Build.php"))
 				</div>
 				</a>
 			</div>
+			<div class="generic-con-button">
+				<a href='https://github.com/RPCS3/rpcs3-binaries-mac/releases/download/build-02362a480712a18cc3567eea2f9195fa65c4e117/rpcs3-v0.0.33-16940-02362a48_macos.7z' target="_blank">
+				<div class="generic-btn-button">
+					<div class="generic-ico-button" style="background: url('/img/icons/buttons/macos-h.png') no-repeat center">
+					</div>
+					<div class="generic-tx1-button">
+						<span>Download <span class="generic-tx2-label">For macOS 12.6</span></span>
+					</div>
+				</div>
+				</a>
+			</div>
+			<div class="generic-con-button">
+				<a href='https://github.com/RPCS3/rpcs3-binaries-mac/releases/download/build-310fa7127d4e6aeaac85f9d4f9efb3635b5d9861/rpcs3-v0.0.25-14517-310fa712_macos.dmg' target="_blank">
+				<div class="generic-btn-button">
+					<div class="generic-ico-button" style="background: url('/img/icons/buttons/macos-h.png') no-repeat center">
+					</div>
+					<div class="generic-tx1-button">
+						<span>Download <span class="generic-tx2-label">For macOS 11.6</span></span>
+					</div>
+				</div>
+				</a>
+			</div>
 			<div class='container-con-block darkmode-block'>
 				<div class='container-con-wrapper'>
 					<div class='container-tx1-block darkmode-txt'>

--- a/public_html/lib/module/download/inc-download-platform.php
+++ b/public_html/lib/module/download/inc-download-platform.php
@@ -133,7 +133,7 @@
 				<span>macOS</span> <span  class='downloadable-tx3-label'->Experimental</span>
 			</div>
 			<div class='downloadable-tx2-desc darkmode-txt'>
-				<span>Users can expect to run RPCS3 on Macs with Apple Silicon or Intel processors with dedicated graphics on macOS 12.6+, 13.0+, 14.3+ or later.</span>
+				<span>Users can expect to run RPCS3 on Macs with Apple Silicon or Intel processors with dedicated graphics on macOS 13.0+, 14.3+, 15.0+ or later.</span>
 			</div>
 			<div class='sha2-tx1-title darkmode-txt'>
 				<span>SHA-256</span>

--- a/public_html/lib/module/download/inc-download-platform.php
+++ b/public_html/lib/module/download/inc-download-platform.php
@@ -197,7 +197,7 @@
 				<span>FreeBSD</span>
 			</div>
 			<div class='downloadable-tx2-desc darkmode-txt'>
-				<span>Users can expect to run RPCS3 at the best possible performance on a wide range of hardware setups on FreeBSD 12.3 or later.<br><br><br><br></span>
+				<span>Users can expect to run RPCS3 at the best possible performance on a wide range of hardware setups on FreeBSD 13.3 or later.<br><br><br><br></span>
 			</div>
 			<a href="https://cgit.freebsd.org/ports/log/emulators/rpcs3">
 			<div class='package-con-button'>

--- a/public_html/lib/module/download/inc-download-platform.php
+++ b/public_html/lib/module/download/inc-download-platform.php
@@ -221,7 +221,6 @@
 			</div>
 			<div class='downloadable-tx2-desc darkmode-txt'>
 				<span>Checking previous builds allows you browse all publicly released official builds. We offer useful metadata for each build such as SHA, OS version, author and the commit it was compiled from. Please be aware that because these are previous builds they may be missing important fixes and additions found in later builds.<br><br>For furthers details see our <a href="https://github.com/RPCS3/rpcs3/commits/master" target="_blank">commits</a> log via GitHub.</span>
-				</span>
 				<br><br>
 			</div>
 			<a href="https://rpcs3.net/compatibility?b">

--- a/public_html/lib/module/quickstart/inc-quickstart-device-requirement.php
+++ b/public_html/lib/module/quickstart/inc-quickstart-device-requirement.php
@@ -136,7 +136,7 @@
 						<p>
 							 Windows
 						</p>
-						<span>Windows 10 22H2 or later, Windows 11 23H2 or later</span><br>
+						<span>Windows 10 22H2 or later, Windows 11 24H2 or later</span><br>
 						<br>
 						<p>
 							 Linux

--- a/public_html/lib/module/quickstart/inc-quickstart-device-requirement.php
+++ b/public_html/lib/module/quickstart/inc-quickstart-device-requirement.php
@@ -146,7 +146,7 @@
 						<p>
 							 macOS
 						</p>
-						<span>macOS 12.6+, 13.0+, 14.3+ or later</span><br>
+						<span>macOS 13.0+, 14.3+, 15.0+ or later</span><br>
 						<br>
 						<p>
 							 FreeBSD
@@ -289,7 +289,7 @@
 						<p>
 							 macOS
 						</p>
-						<span>macOS 12.6+, 13.0+, 14.3+ or later</span><br>
+						<span>macOS 13.0+, 14.3+, 15.0+ or later</span><br>
 						<br>
 						<p>
 							 FreeBSD


### PR DESCRIPTION
- download: Fix HTML syntax error
- download: Fix MSVC Redistributable version text
- download: Remove macOS 12.6 as supported, add macOS 15.0
- download: Remove FreeBSD 12.3 as supported, add FreeBSD 14.0
- download: Add download buttons for macOS 12 and macOS 11 legacy builds
- quickstart: Remove macOS 12.6 as supported, add macOS 15.0
- quickstart: Update Windows 11 recommendation from 23H2 to 24H2 