### PR TITLE
requirements: Update macOS, FreeBSD, Windows, ATI, NVIDIA

### DIFF
--- a/public_html/download.php
+++ b/public_html/download.php
@@ -115,6 +115,24 @@ if (@include_once("lib/compat/objects/Build.php"))
 					</div>
 				</div>
 				</a>
+				<a href='https://github.com/RPCS3/rpcs3-binaries-mac-arm64/releases/download/build-6a15f9dc8ea46fafccdebebe9b57e21bbd5e7426/rpcs3-v0.0.41-19492-6a15f9dc_macos_aarch64.7z' target="_blank">
+				<div class="generic-btn-button">
+					<div class="generic-ico-button" style="background: url('/img/icons/buttons/macos-h.png') no-repeat center">
+					</div>
+					<div class="generic-tx1-button">
+						<span>Download <span class="generic-tx2-label">For macOS 14.4 (arm64)</span></span>
+					</div>
+				</div>
+				</a>
+				<a href='https://github.com/RPCS3/rpcs3-binaries-mac/releases/download/build-6a15f9dc8ea46fafccdebebe9b57e21bbd5e7426/rpcs3-v0.0.41-19492-6a15f9dc_macos.7z' target="_blank">
+				<div class="generic-btn-button">
+					<div class="generic-ico-button" style="background: url('/img/icons/buttons/macos-h.png') no-repeat center">
+					</div>
+					<div class="generic-tx1-button">
+						<span>Download <span class="generic-tx2-label">For macOS 14.4 (x64)</span></span>
+					</div>
+				</div>
+				</a>
 				<a href='https://github.com/RPCS3/rpcs3-binaries-mac-arm64/releases/download/build-563a3d3587b309bdbad947363faf1b9dab434d46/rpcs3-v0.0.35-17589-563a3d35_macos_arm64.7z' target="_blank">
 				<div class="generic-btn-button">
 					<div class="generic-ico-button" style="background: url('/img/icons/buttons/macos-h.png') no-repeat center">

--- a/public_html/lib/module/download/inc-download-platform.php
+++ b/public_html/lib/module/download/inc-download-platform.php
@@ -366,7 +366,7 @@
 				<span>FreeBSD</span>
 			</div>
 			<div class='downloadable-tx2-desc darkmode-txt'>
-				<span>Users can expect to run RPCS3 at the best possible performance on a wide range of hardware setups on FreeBSD 13.5 or later.<br><br><br><br></span>
+				<span>Users can expect to run RPCS3 at the best possible performance on a wide range of hardware setups on FreeBSD 14.4 or later.<br><br><br><br></span>
 			</div>
 			<a href="https://cgit.freebsd.org/ports/log/emulators/rpcs3">
 			<div class='package-con-button'>

--- a/public_html/lib/module/download/inc-download-platform.php
+++ b/public_html/lib/module/download/inc-download-platform.php
@@ -246,7 +246,7 @@
 				<span>macOS</span> <span  class='downloadable-tx3-label'>Experimental</span>
 			</div>
 			<div class='downloadable-tx2-desc darkmode-txt'>
-				<span>For Apple Silicon or Intel hardware with dedicated graphics on macOS 14.4+, 15.0+ or later.</span>
+				<span>For Apple Silicon or Intel hardware with dedicated graphics on macOS 15 or later.</span>
 			</div>
 			<!-- SHA Section -->
 			<div class='sha2-tx1-title darkmode-txt'>

--- a/public_html/lib/module/quickstart/inc-quickstart-device-inputs.php
+++ b/public_html/lib/module/quickstart/inc-quickstart-device-inputs.php
@@ -59,7 +59,7 @@
 				</div>
 				<div class='device-tx2-desc darkmode-txt'>
 					<span>
-					Expect decent performance on Macs with high-end Intel CPUs and variable performance with Apple Silicon on macOS 14.4+, 15.0+ or later.<br>
+					Expect decent performance on Macs with high-end Intel CPUs and variable performance with Apple Silicon on macOS 15 or later.<br>
 					<br>
 					 See the <b>For Mac</b> section for more details. </span>
 				</div>

--- a/public_html/lib/module/quickstart/inc-quickstart-device-requirement.php
+++ b/public_html/lib/module/quickstart/inc-quickstart-device-requirement.php
@@ -157,7 +157,7 @@
 						<p>
 							 FreeBSD
 						</p>
-						<span>FreeBSD 13.5+, 14.3+, 15.0+ or later</span>
+						<span>FreeBSD 14.4+, 15.0+ or later</span>
 					</div>
 				</div>
 			</div>
@@ -306,7 +306,7 @@
 						<p>
 							 FreeBSD
 						</p>
-						<span>FreeBSD 13.5 or later</span>
+						<span>FreeBSD 14.4 or later</span>
 					</div>
 				</div>
 			</div>

--- a/public_html/lib/module/quickstart/inc-quickstart-device-requirement.php
+++ b/public_html/lib/module/quickstart/inc-quickstart-device-requirement.php
@@ -152,7 +152,7 @@
 						<p>
 							 macOS
 						</p>
-						<span>macOS 14.4+, 15.0+ or later</span><br>
+						<span>macOS 15 or later</span><br>
 						<br>
 						<p>
 							 FreeBSD
@@ -301,7 +301,7 @@
 						<p>
 							 macOS
 						</p>
-						<span>macOS 14.4+, 15.0+ or later</span><br>
+						<span>macOS 15 or later</span><br>
 						<br>
 						<p>
 							 FreeBSD

--- a/public_html/lib/module/quickstart/inc-quickstart-device-requirement.php
+++ b/public_html/lib/module/quickstart/inc-quickstart-device-requirement.php
@@ -142,7 +142,7 @@
 						<p>
 							 Windows
 						</p>
-						<span>Windows 11 24H2 or later</span><br>
+						<span>Windows 11 25H2 or later</span><br>
 						<br>
 						<p>
 							 Linux

--- a/public_html/requirements.php
+++ b/public_html/requirements.php
@@ -190,7 +190,7 @@
 					</td>
 					<td>
 						<ul class="requirements-cell-list">
-							<li>ATI HD 5450</li>
+							<li>ATI HD 5550</li>
 							<li>NVIDIA GT 420</li>
 							<li>Intel Arc A310</li>
 						</ul>

--- a/public_html/requirements.php
+++ b/public_html/requirements.php
@@ -122,7 +122,7 @@
 						<ul class="requirements-cell-list">
 							<li>Linux</li>
 							<li>Windows 10</li>
-							<li>macOS 14</li>
+							<li>macOS 15</li>
 							<li>FreeBSD 14</li>
 						</ul>
 					</td>

--- a/public_html/requirements.php
+++ b/public_html/requirements.php
@@ -191,7 +191,7 @@
 					<td>
 						<ul class="requirements-cell-list">
 							<li>ATI HD 5550</li>
-							<li>NVIDIA GT 420</li>
+							<li>NVIDIA GT 430</li>
 							<li>Intel Arc A310</li>
 						</ul>
 					</td>


### PR DESCRIPTION
- requirements: Bump minimum macOS to 15.0
- requirements: Update recommended Windows to 25H2
- requirements: Bump minimum FreeBSD to 14.4
- requirements: Bump minimum ATI to HD 5550
  - HD 5450 is not a gaming card, too slow for shader execution.
- requirements: Bump minimum NVIDIA to GT 430
  - GT 420 is not a gaming card, too slow for shader execution.
- download: Add last builds for macOS 14